### PR TITLE
Update squirrel.custom.yaml

### DIFF
--- a/squirrel.custom.yaml
+++ b/squirrel.custom.yaml
@@ -22,7 +22,7 @@ patch:
     purity_of_form_custom:
       name: "純粹的形式／Purity of Form Custom"
       author: 雨過之後、佛振
-      font_face: ""                   # 字体及大小
+      font_face: "PingFang SC"                   # 字体及大小
       font_point: 18
       label_font_face: "Helvetica"    # 序号字体及大小
       label_font_point: 12


### PR DESCRIPTION
新版 Squirrel 更新后默认字体会变为微软雅黑，建议作者在外观的配置文件中直接加入苹方字体