### PR TITLE
勘误

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -227,7 +227,6 @@ sort: by_weight
 三个䖝	san ge chong
 三个丿	san ge pie
 三个户
-三个日
 三个瓜
 三个鸟
 三个米
@@ -249,7 +248,6 @@ sort: by_weight
 四个魚	si ge yu
 四个月
 四个日
-四个曰
 四个林
 四个水
 四个石


### PR DESCRIPTION
---others.dict.yaml
三个日	重复
四个曰	不是名词
---base.dict.yaml
别传    没有bie chuan的音
出车    没有chu ju	
隔宿之仇	没有ge xiu zhi chou
蚝仔煎	没有hao zi jian
户给人足	没有hu gei ren zu	1