### PR TITLE
Switch to pure english input when press shift

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -54,8 +54,8 @@ switcher:
 ascii_composer:
   good_old_caps_lock: true  # true | false
   switch_key:
-    Caps_Lock: clear  # commit_code | commit_text | clear
-    Shift_L: noop     # commit_code | commit_text | inline_ascii | clear | noop
+    Caps_Lock: commit_code  # commit_code | commit_text | clear
+    Shift_L: commit_code     # commit_code | commit_text | inline_ascii | clear | noop
     Shift_R: noop     # commit_code | commit_text | inline_ascii | clear | noop
     Control_L: noop   # commit_code | commit_text | inline_ascii | clear | noop
     Control_R: noop   # commit_code | commit_text | inline_ascii | clear | noop


### PR DESCRIPTION
这一点和中文输入法保持一致，当按下 Cap 和 Shift 键的时候，将输入模式调整为英文输入。建议作为默认配置