### PR TITLE
改进 v_filter 的性能

### DIFF
--- a/rime.lua
+++ b/rime.lua
@@ -237,29 +237,36 @@ end
 -- 把候选项应改为「ā á ǎ à …… van vain」，让单个字符的排在前面
 function v_filter(input, env)
     local code = env.engine.context.input -- 当前编码
-    local l = {}
-    for cand in input:iter() do
-        -- 特殊情况处理
-        if (cand.text == "Vs.") then
-            yield(cand)
-        end
-        -- 特殊情况处理
-        local arr = {"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"}
-        for _, v in ipairs(arr) do
-            if (v == cand.text and string.len(code) == 2 and string.find(code, "v") == 1) then
+    -- 仅当当前输入以 v 开头，并且编码长度为 2，才进行处理
+    if (string.len(code) == 2 and string.find(code, "v") == 1) then
+        local l = {}
+        for cand in input:iter() do
+            -- 特殊情况处理
+            if (cand.text == "Vs.") then
                 yield(cand)
-                break
+            end
+            -- 特殊情况处理
+            local arr = { "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣" }
+            for _, v in ipairs(arr) do
+                if (v == cand.text) then
+                    yield(cand)
+                    break
+                end
+            end
+            -- 候选项为单个字符的，提到前面来。
+            if (utf8.len(cand.text) == 1) then
+                yield(cand)
+            else
+                table.insert(l, cand)
             end
         end
-        -- 以 v 开头、2 个长度的编码、候选项为单个字符的，提到前面来。
-        if (string.len(code) == 2 and string.find(code, "v") == 1 and utf8.len(cand.text) == 1) then
+        for _, cand in ipairs(l) do
             yield(cand)
-        else
-            table.insert(l, cand)
         end
-    end
-    for _, cand in ipairs(l) do
-        yield(cand)
+    else
+        for cand in input:iter() do
+            yield(cand)
+        end
     end
 end
 -------------------------------------------------------------


### PR DESCRIPTION
在进行普通输入（非 v 开头）时，`v_filter` 会把所有的候选项先读入数组，再进行处理，这会导致 rime 遍历所有的候选项，减慢执行速度。本更改将输入条件的判断提前，在函数一开始就进行，如果不是 v 开头的输入就直接 yield 返回，这样 rime 就不用遍历所有候选项即可返回结果。此性能损失在 webassembly 等性能较差的环境中尤为明显。改进前，输入 `s` 字母（s 开头的候选项较多），需要 300ms 才能计算出候选列表；改进后，只需要 60ms，且这 60ms 中大部分是被 `long_word_filter` 消耗了。`long_word_filter` 也有同样的性能问题，该函数逻辑较复杂，目前我没有想出较好的解决方法。去除 `long_word_filter` 并使用优化版本的 `v_filter`，只需 6ms 就能计算出列表。