### PR TITLE
修复以词定字.lua错误

### DIFF
--- a/lua/select_character.lua
+++ b/lua/select_character.lua
@@ -1,7 +1,7 @@
 -- 以词定字
 -- 来源 https://github.com/BlindingDark/rime-lua-select-character
 -- 删除了默认按键 [ ]，和方括号翻页冲突，需要在 key_binder 下指定才能生效
--- 20230526184754 不再错误地获取commit_text，而是直接获取get_selected_candidate().text。
+-- 20230526195910 不再错误地获取commit_text，而是直接获取get_selected_candidate().text。
 local function utf8_sub(s, i, j)
     i = i or 1
     j = j or -1
@@ -46,26 +46,29 @@ local function utf8_sub(s, i, j)
 end
 
 local function select_character(key, env)
-    -- local first_key = engine.schema.config:get_string('key_binder/select_first_character') or 'bracketleft'
-    -- local last_key = engine.schema.config:get_string('key_binder/select_last_character') or 'bracketright'
-    local first_key = engine.schema.config:get_string('key_binder/select_first_character')
-    local last_key = engine.schema.config:get_string('key_binder/select_last_character')
+    local engine = env.engine
+    local context = engine.context
+    local commit_text = context:get_commit_text()
+    local config = engine.schema.config
 
-    if(key:repr() == first_key)then
-        local slct_text = env.engine.context:get_selected_candidate().text
-        if(slct_text)then
-            env.engine:commit_text(utf8_sub(slct_text, 1, 1))
-            env.engine.context:clear()
+    -- local first_key = config:get_string('key_binder/select_first_character') or 'bracketleft'
+    -- local last_key = config:get_string('key_binder/select_last_character') or 'bracketright'
+    local first_key = config:get_string('key_binder/select_first_character')
+    local last_key = config:get_string('key_binder/select_last_character')
 
+    if (key:repr() == first_key) then
+        if(context:get_selected_candidate().text)then
+            engine:commit_text(utf8_sub(context:get_selected_candidate().text, 1, 1))
+            context:clear()
+        end
         return 1 -- kAccepted
     end
 
-    if(key:repr() == last_key)then
-        local slct_text = env.engine.context:get_selected_candidate().text
-        if(slct_text)then
-            env.engine:commit_text(utf8_sub(slct_text, 1, 1))
-            env.engine.context:clear()
-
+    if (key:repr() == last_key) then
+        if(context:get_selected_candidate().text)then
+            engine:commit_text(utf8_sub(context:get_selected_candidate().text,-1,-1))
+            context:clear()
+        end
         return 1 -- kAccepted
     end
 

--- a/lua/select_character.lua
+++ b/lua/select_character.lua
@@ -1,6 +1,7 @@
 -- 以词定字
 -- 来源 https://github.com/BlindingDark/rime-lua-select-character
 -- 删除了默认按键 [ ]，和方括号翻页冲突，需要在 key_binder 下指定才能生效
+-- 20230526184754 不再错误地获取commit_text，而是直接获取get_selected_candidate().text。
 local function utf8_sub(s, i, j)
     i = i or 1
     j = j or -1
@@ -44,35 +45,26 @@ local function utf8_sub(s, i, j)
     end
 end
 
-local function first_character(s)
-    return utf8_sub(s, 1, 1)
-end
-
-local function last_character(s)
-    return utf8_sub(s, -1, -1)
-end
-
 local function select_character(key, env)
-    local engine = env.engine
-    local context = engine.context
-    local commit_text = context:get_commit_text()
-    local config = engine.schema.config
+    -- local first_key = engine.schema.config:get_string('key_binder/select_first_character') or 'bracketleft'
+    -- local last_key = engine.schema.config:get_string('key_binder/select_last_character') or 'bracketright'
+    local first_key = engine.schema.config:get_string('key_binder/select_first_character')
+    local last_key = engine.schema.config:get_string('key_binder/select_last_character')
 
-    -- local first_key = config:get_string('key_binder/select_first_character') or 'bracketleft'
-    -- local last_key = config:get_string('key_binder/select_last_character') or 'bracketright'
-    local first_key = config:get_string('key_binder/select_first_character')
-    local last_key = config:get_string('key_binder/select_last_character')
-
-    if (key:repr() == first_key and commit_text ~= "") then
-        engine:commit_text(first_character(commit_text))
-        context:clear()
+    if(key:repr() == first_key)then
+        local slct_text = env.engine.context:get_selected_candidate().text
+        if(slct_text)then
+            env.engine:commit_text(utf8_sub(slct_text, 1, 1))
+            env.engine.context:clear()
 
         return 1 -- kAccepted
     end
 
-    if (key:repr() == last_key and commit_text ~= "") then
-        engine:commit_text(last_character(commit_text))
-        context:clear()
+    if(key:repr() == last_key)then
+        local slct_text = env.engine.context:get_selected_candidate().text
+        if(slct_text)then
+            env.engine:commit_text(utf8_sub(slct_text, 1, 1))
+            env.engine.context:clear()
 
         return 1 -- kAccepted
     end


### PR DESCRIPTION
![Animation](https://github.com/iDvel/rime-ice/assets/32760059/1849d44a-edff-4d88-a4d3-dd9c8ab05beb)

修复了图示错误，即在光标不在末尾时使用执行select_last_character时，会输出末位输入码。