### PR TITLE
修改 lua 英文词匹配条件 fix #349

### DIFF
--- a/lua/reduce_english_filter.lua
+++ b/lua/reduce_english_filter.lua
@@ -22,7 +22,8 @@ local function reduce_english_filter(input, env)
         local index = 0
         for cand in input:iter() do
             index = index + 1
-            if string.lower(cand.text) == code then
+            -- 定位匹配的英文词
+            if not string.find( cand.preedit , " ") then
                 table.insert(pending_cands, cand)
             else
                 yield(cand)

--- a/lua/reduce_english_filter.lua
+++ b/lua/reduce_english_filter.lua
@@ -23,7 +23,7 @@ local function reduce_english_filter(input, env)
         for cand in input:iter() do
             index = index + 1
             -- 定位匹配的英文词
-            if not string.find( cand.preedit , " ") then
+            if not string.find(cand.preedit, " ") then
                 table.insert(pending_cands, cand)
             else
                 yield(cand)

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -105,7 +105,7 @@ reduce_english_filter:
   lux, moc, mos, mot, mum, nad, nay, nib, nip, pak, pap, pax, rig, rum, sac, sal,
   sax, sec, shin, sis, ska, slang, sus, tad, taj, tac, tic, yep, yum, fax, cain,
   key, mob, buy, dam, wap, yes, but, put, lag, buf, lip, aid, aim, dig, dim, din,
-  dip, pail, cad, chap, bend , diann]
+  dip, pail, cad, chap, bend]
 
 
 # 引入八股文

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -105,7 +105,7 @@ reduce_english_filter:
   lux, moc, mos, mot, mum, nad, nay, nib, nip, pak, pap, pax, rig, rum, sac, sal,
   sax, sec, shin, sis, ska, slang, sus, tad, taj, tac, tic, yep, yum, fax, cain,
   key, mob, buy, dam, wap, yes, but, put, lag, buf, lip, aid, aim, dig, dim, din,
-  dip, pail, cad, chap, bend]
+  dip, pail, cad, chap, bend , diann]
 
 
 # 引入八股文


### PR DESCRIPTION
.NET 权重只会影响全拼。双拼下汉语剩余码长为 1，大于 .NET 的 2，因而会排在汉语后。所以只改了 rime_ice。

可以用编码不含空格匹配到英文的原因是：
- 汉语词汇编码由 script_translator 控制，音节间一定含空格；
- 英文编码由 table_translator 负责，不能含有空格；
- 单个汉字编码虽然不含有空格，此时由于词库权重设计，英文不会排在汉字前，无需过滤。

close #349 