### PR TITLE
doc: 为小狼毫配置提供详细文档

### DIFF
--- a/weasel_style.yaml
+++ b/weasel_style.yaml
@@ -31,10 +31,10 @@ style:
   # 布局设定，同样可以在 layout 的 type 下指定
   fullscreen: false # 全屏排列：true；false
   horizontal: false # 横向排列：true；false
-  vertical_text: false # 竖直排列：true；false
-  vertical_text_left_to_right: false # 竖直排列下从左到右：true；false
-  vertical_text_with_wrap: false # 竖直排列下，自动换行：true；false
-  vertical_auto_reverse: false # 竖直布局下，输入窗口在上方时倒序排列：true；false
+  vertical_text: false # 竖排：true；false
+  vertical_text_left_to_right: false # 竖排下从左到右：true；false
+  vertical_text_with_wrap: false # 竖排下，自动换行：true；false
+  vertical_auto_reverse: false # 竖排下，输入窗口在上方时倒序排列：true；false
 
   label_format: "%s." # 标签字符：%s. 效果为 1. 2. 3. ....
   mark_text: "" # 高亮字符，显示在选中的候选标签前
@@ -49,7 +49,7 @@ style:
     max_width: 0 # 候选框最大宽度，超过会折叠
     min_height: 0 # 最小高度
     min_width: 160
-    type: horizontal # horizontal（横向）；vertical（竖向） ; vertical_text（文本竖直） ; vertical+fullscreen（竖向全屏） ; horizontal+fullscreen（横向全拼）
+    type: horizontal # horizontal（横向）；vertical（竖向） ; vertical_text（竖排文本） ; vertical+fullscreen（全屏） ; horizontal+fullscreen（横向全屏）
     border_width: 3 # 边框宽度，又名 border
     margin_x: 12 # 元素偏离候选边框 X 轴距离；为负值时，不显示候选框
     margin_y: 12 # 元素偏离候选边框 Y 轴距离；为负值时，不显示候选框
@@ -69,8 +69,7 @@ style:
 # 在小狼毫用户目录新建 preview 文件夹，将自定义皮肤的截图重命名为 color_scheme_<name>.png 放入此文件夹，可以在「输入法设定」中看到自定义皮肤效果
 
 # 小狼毫配色在线设计：
-# [RIME 西米](https://bennyyip.github.io/Rime-See-Me/)
-# [润笔](https://pdog18.github.io/rime-soak/#/theme)
+# [RIME 西米](https://fxliang.github.io/RimeSeeMe/)
 
 preset_color_schemes:
   scheme_name: # 需要在 `style/color_schema` 指定的值

--- a/weasel_style.yaml
+++ b/weasel_style.yaml
@@ -1,0 +1,140 @@
+# weasel.yaml 支持的所有选项及注释，用于配置参考
+
+# 小狼毫会在更换配色时将 weasel.custom.yaml 内容格式化，删除所有注释并调整格式。建议的自定义方法是：复制本文件并修改，之后在 weasel.custom.yaml 用 `__include` 引入。示例 weasel.custom.yaml 如下：
+# patch:
+#   "preset_color_schemes/+"
+#     __include: "weasel_style_copy:/preset_color_schemes"
+#   "style/+":
+#     __include: "weasel_style_copy:/style"
+
+
+# 全部 style 选项
+# refer：<https://github.com/rime/weasel/blob/master/RimeWithWeasel/RimeWithWeasel.cpp>
+# Update at：2023.06.15
+# Weasel 版本：15.0 
+# Commit: 15f94f76967
+style:
+  # 字体设定
+  # 字体1[:起始码位:结束码位:字重:字形][,字体2 ...]，例如：
+  # "Segoe UI Emoji:20:39:bold:italic, Noto Color Emoji SVG:80, Arial:600:6ff, Segoe UI Emoji:80, LXGW Wenkai Narrow"
+  # 字体会依次 fallback
+  font_face: "Segoe UI Emoji:80, Microsoft YaHei" # 默认字体。为了保证部分 emoji 能正常显示，建议将 emoji 字体放在首位，并指定起始码位防止影响其他字符。refer <https://github.com/rime/weasel/issues/932>
+  label_font_face: "Microsoft YaHei" # 标签字体
+  comment_font_face: "Microsoft YaHei" # 注释字体
+  font_point: 14 # 默认字体大小
+  label_font_point: 14 # 标签字体大小，不设定 fallback 到 font_point
+  comment_font_point: 14 # 注释字体大小，不设定 fallback 到 font_point
+
+  inline_preedit: false # 行内显示预编辑区：true；false
+  preedit_type: composition # 预编辑区内容：composition（编码）； preview（高亮候选）；preview_all（全部候选）
+
+  # 布局设定，同样可以在 layout 的 type 下指定
+  fullscreen: false # 全屏排列：true；false
+  horizontal: false # 横向排列：true；false
+  vertical_text: false # 竖直排列：true；false
+  vertical_text_left_to_right: false # 竖直排列下从左到右：true；false
+  vertical_text_with_wrap: false # 竖直排列下，自动换行：true；false
+  vertical_auto_reverse: false # 竖直布局下，输入窗口在上方时倒序排列：true；false
+
+  label_format: "%s." # 标签字符：%s. 效果为 1. 2. 3. ....
+  mark_text: "" # 高亮字符，显示在选中的候选标签前
+  ascii_tip_follow_cursor: false # 切换 ASCII 模式时，图标跟随光标
+  enhanced_position: false # 无法定位候选框时，在窗口窗口左上角显示候选框：true；false
+  display_tray_icon: false # 托盘显示独立于语言栏的额外图标：true；false
+  antialias_mode: default # 次像素反锯齿设定：default；force_dword；cleartype；grayscale；aliased
+
+  layout:
+    align_type: center # 对齐：top ; center ; bottom
+    max_height: 0 # 候选框最大高度
+    max_width: 0 # 候选框最大宽度，超过会折叠
+    min_height: 0 # 最小高度
+    min_width: 160
+    type: horizontal # horizontal（横向）；vertical（竖向） ; vertical_text（文本竖直） ; vertical+fullscreen（竖向全屏） ; horizontal+fullscreen（横向全拼）
+    border_width: 3 # 边框宽度，又名 border
+    margin_x: 12 # 元素偏离候选边框 X 轴距离；为负值时，不显示候选框
+    margin_y: 12 # 元素偏离候选边框 Y 轴距离；为负值时，不显示候选框
+    spacing: 10 # 默认间隙
+    candidate_spacing: 5 # 候选项之间的间隔
+    hilite_spacing: 4 # 候选和标签的间隔
+    hilite_padding: 2 # 高亮区域和边框的间隔。当值 ≥ margin 的值时，高亮颜色会覆盖整个选中的候选区域，实现「天圆地方」的效果。参考文件末的配置
+    shadow_offset_x: 4 # 阴影偏离和圆角大小
+    shadow_offset_y: 4
+    shadow_radius: 0
+    corner_radius: 4 # 候选框圆角
+    round_corner: 4  # 高亮区域圆角；又名 hilited_corner_radius
+
+
+# 全部 color_schemes 选项，点击小狼毫「输入法设定」可以预览皮肤效果
+
+# 在小狼毫用户目录新建 preview 文件夹，将自定义皮肤的截图重命名为 color_scheme_<name>.png 放入此文件夹，可以在「输入法设定」中看到自定义皮肤效果
+
+# 小狼毫配色在线设计：
+# [RIME 西米](https://bennyyip.github.io/Rime-See-Me/)
+# [润笔](https://pdog18.github.io/rime-soak/#/theme)
+
+preset_color_schemes:
+  scheme_name: # 需要在 `style/color_schema` 指定的值
+    name: # 方案设置中显示的配色名称
+    author:
+    color_format: # 颜色格式：argb；rgba
+    # 默认
+    back_color: # 背景
+    border_color: # 边框
+    comment_text_color: # 注释
+    label_color: # 标签
+    shadow_color: # 阴影
+    text_color: # 文字
+    # 候选区域
+    candidate_back_color:
+    candidate_border_color:
+    candidate_shadow_color:
+    candidate_text_color:
+    # 高亮区域
+    hilited_back_color:
+    hilited_comment_text_color:
+    hilited_label_color:
+    hilited_mark_color:
+    hilited_shadow_color:
+    hilited_text_color:
+    # 高亮的候选区域
+    hilited_candidate_back_color:
+    hilited_candidate_border_color:
+    hilited_candidate_shadow_color:
+    hilited_candidate_text_color:
+    # 翻页
+    nextpage_color:
+    prevpage_color:
+
+
+# 为特定的应用单独设定选项
+app_options:
+  appname.exe: # 带 .exe 的进程名，全小写
+    ascii_mode: true # 英文模式
+  appname2.exe:
+    ascii_mode: false # 非英文模式
+
+
+# 以下是一个示例方案
+# 使用方法：在 weasel.custom.yaml 中添加如下两行：
+# "style/+":
+#   __include: "weasel_style:/style_inline_horizontal"
+style_inline_horizontal:
+  font_point: 14
+  comment_font_point: 13
+  inline_preedit: true
+  mark_text: "|" 
+  ascii_tip_follow_cursor: true
+  enhanced_position: true
+  layout:
+    align_type: center
+    max_width: 1080 
+    max_height: 600
+    type: horizontal
+    border_width: 2
+    margin_x: 8
+    margin_y: 8
+    candidate_spacing: 20
+    hilite_padding: 8
+    hilite_spacing: 2
+    corner_radius: 8
+    round_corner: 8


### PR DESCRIPTION
参照 [squirrel.yaml](https://github.com/iDvel/rime-ice/blob/main/squirrel.yaml) 的做法，参考小狼毫的相关源码，为小狼毫平台配置写了 doc。

不直接命名为 weasel.yaml 的考虑是：小狼毫当前变动比较频繁，默认配置很可能会修改