### PR TITLE
command.lua

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -233,7 +233,7 @@ key_binder:
 # 拼写设定
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     - erase/^xx$/

--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -53,6 +53,7 @@ switches:
 engine:
   processors:
     - lua_processor@select_character      # 以词定字
+    - lua_processor@command               # Tab补全命令
     - ascii_composer
     - recognizer
     - key_binder
@@ -69,6 +70,7 @@ engine:
     - fallback_segmentor
   translators:
     - punct_translator
+    - lua_translator@commandhint          # 响应指令并打印结果
     - script_translator
     - lua_translator@date_translator      # 时间、日期、星期
     - table_translator@custom_phrase      # 自定义短语 custom_phrase_double.txt

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -52,6 +52,7 @@ switches:
 engine:
   processors:
     - lua_processor@select_character      # 以词定字
+    - lua_processor@command               # Tab补全命令
     - ascii_composer
     - recognizer
     - key_binder
@@ -68,6 +69,7 @@ engine:
     - fallback_segmentor
   translators:
     - punct_translator
+    - lua_translator@commandhint          # 响应指令并打印结果
     - script_translator
     - lua_translator@date_translator      # 时间、日期、星期
     - table_translator@custom_phrase      # 自定义短语 custom_phrase_double.txt

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -235,7 +235,7 @@ key_binder:
 # 拼写设定
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     - erase/^xx$/

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -233,7 +233,7 @@ key_binder:
 # 拼写设定
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     - erase/^xx$/

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -53,6 +53,7 @@ switches:
 engine:
   processors:
     - lua_processor@select_character      # 以词定字
+    - lua_processor@command               # Tab补全命令
     - ascii_composer
     - recognizer
     - key_binder
@@ -69,6 +70,7 @@ engine:
     - fallback_segmentor
   translators:
     - punct_translator
+    - lua_translator@commandhint          # 响应指令并打印结果
     - script_translator
     - lua_translator@date_translator      # 时间、日期、星期
     - table_translator@custom_phrase      # 自定义短语 custom_phrase_double.txt

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -237,7 +237,7 @@ key_binder:
 # 拼写设定
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA;
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/;
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     - erase/^xx$/

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -53,6 +53,7 @@ switches:
 engine:
   processors:
     - lua_processor@select_character      # 以词定字
+    - lua_processor@command               # Tab补全命令
     - ascii_composer
     - recognizer
     - key_binder
@@ -69,6 +70,7 @@ engine:
     - fallback_segmentor
   translators:
     - punct_translator
+    - lua_translator@commandhint          # 响应指令并打印结果
     - script_translator
     - lua_translator@date_translator      # 时间、日期、星期
     - table_translator@custom_phrase      # 自定义短语 custom_phrase_double.txt

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -235,7 +235,7 @@ key_binder:
 # 拼写设定
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA;
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/;
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     - erase/^xx$/

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -53,6 +53,7 @@ switches:
 engine:
   processors:
     - lua_processor@select_character      # 以词定字
+    - lua_processor@command               # Tab补全命令
     - ascii_composer
     - recognizer
     - key_binder
@@ -69,6 +70,7 @@ engine:
     - fallback_segmentor
   translators:
     - punct_translator
+    - lua_translator@commandhint          # 响应指令并打印结果
     - script_translator
     - lua_translator@date_translator      # 时间、日期、星期
     - table_translator@custom_phrase      # 自定义短语 custom_phrase_double.txt

--- a/lua/command.lua
+++ b/lua/command.lua
@@ -1,0 +1,80 @@
+local map
+do
+local Sep=package.config:sub(1, 1)
+local user=rime_api:get_user_data_dir()
+local data=rime_api:get_shared_data_dir()
+local program=data:sub(1,-6)
+local build=user..Sep.."build"
+map={
+ -- ["/sep"]={{Sep,"分隔符"}},
+ ["/user"]={{user,"用户文件夹"}},
+ ["/data"]={{data,"共享文件夹"}},
+ ["/program"]={{program,"程序文件夹"}},
+ ["/build"]={{build,"部署文件夹"}},
+ ["/lua"]={{data..Sep.."lua","lua文件夹"}},
+ ["/opencc"]={{data..Sep.."opencc","滤镜文件夹"}},
+}
+end
+local K={
+ ["Tab"]={["Tab"]=true},
+ ["BackSpace"]={["BackSpace"]=true},
+}
+local Valid={}
+for _,v in pairs(K)do
+ for k,_ in pairs(v)do
+  Valid[k]=true
+ end
+end
+local cpl_map={}
+local symbol="/"
+local symbol_l=#symbol
+return {
+ function(key,env)
+  key=key:repr()
+  if env.engine.context.input=="" then cpl_map={} return 2 end
+  if not Valid[key] then return 2 end--键不合法则直接Return
+  local input=env.engine.context.input:lower()
+  if input:find("^"..symbol) then--命令未完整进入补全状态
+   if #cpl_map==0 then--命令未完整且 cpl_map 长度为零则重新获取 cpl_map 补全列表
+    for k,v in pairs(map) do
+     if k:find("^"..input..".") then
+      cpl_map[#cpl_map+1]=k:sub(1+symbol_l)
+     end
+    end
+    table.sort(cpl_map,function(a,b) return #a>#b end)
+    table.insert(cpl_map,1,input:sub(1+symbol_l))
+   end
+   if K.Tab[key] then--补全状态按 Tab 可以在 cpl_map 列表中循环
+    env.engine.context:pop_input(#input-symbol_l)
+    env.engine.context:push_input(cpl_map[#cpl_map])
+    table.remove(cpl_map,#cpl_map)
+    return 1
+   end
+   if K.BackSpace[key] and input:sub(1+symbol_l)~=cpl_map[1] then--补全状态按 BackSpace 会退出补全状态并归还编码
+    env.engine.context:pop_input(#input-symbol_l)
+    env.engine.context:push_input(cpl_map[1])
+    cpl_map={}
+    return 1
+   end
+   cpl_map={}
+  end
+  return 2
+ end
+ ,
+ function(_,seg,env)
+  local input=env.engine.context.input:lower()
+  if map[input] then
+   for i=1,#map[input] do
+    local cand=Candidate("command",seg.start,seg._end,map[input][i][1],map[input][i][2])
+    cand.quality=8102
+    yield(cand)
+   end
+  else
+   if input:find("^"..symbol) then
+    local cand=Candidate("command",seg.start,seg._end,"Tab补全命令","")
+    cand.quality=8102
+    yield(cand)
+   end
+  end
+ end
+}

--- a/rime.lua
+++ b/rime.lua
@@ -58,3 +58,9 @@ is_in_user_dict = require("is_in_user_dict")
 -- drop_cand: "Control+d"       # 强制删词, 无视输入的编码
 cold_word_drop_processor = require("cold_word_drop.processor")
 cold_word_drop_filter = require("cold_word_drop.filter")
+
+do
+local a=require("command")
+command=a[1]
+commandhint=a[2]
+end

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -43,6 +43,7 @@ switches:
 engine:
   processors:
     - lua_processor@select_character      # 以词定字
+    - lua_processor@command               # Tab补全命令
     - ascii_composer
     - recognizer
     - key_binder
@@ -59,6 +60,7 @@ engine:
     - fallback_segmentor
   translators:
     - punct_translator
+    - lua_translator@commandhint          # 响应指令并打印结果
     - script_translator
     - lua_translator@date_translator      # 时间、日期、星期
     - table_translator@custom_phrase      # 自定义短语 custom_phrase.txt
@@ -193,7 +195,8 @@ key_binder:
 # 拼写设定
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
+  initials: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     ### 模糊音

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -196,7 +196,6 @@ key_binder:
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
   alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
-  initials: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     ### 模糊音


### PR DESCRIPTION
考虑到雾凇拼音的用户新手居多，我制作了一个小lua插件，可以帮助新手找到正确的"共享" "用户" "程序" 等文件夹的路径
这个小插件可以促进开发者和用户的沟通，减少老手和新手之间的信息差和学习成本，用户无须明白各个文件夹之间的区别和具体位置，开发者只需要告诉用户输入某个命令，进入这个目录就可以执行修改操作
例如：

https://github.com/iDvel/rime-ice/assets/32760059/9851a49b-9a2d-4c23-8ab6-c56aeb4e5df0

> Tab补全命令、BackSpace

具体配置方法如下：
`xxx.schema.yaml`
```diff
engine:
  processors:
+    - lua_processor@command
  translators:
+    - lua_processor@commandhint
speller:
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA/
```
`rime.lua`
```diff
cold_word_drop_processor = require("cold_word_drop.processor")
cold_word_drop_filter = require("cold_word_drop.filter")
...
+do
+local a=require("command")
+command=a[1]
+commandhint=a[2]
+end
```

图示：
![image](https://github.com/iDvel/rime-ice/assets/32760059/c16a8e07-fae0-4220-89b5-0ef51d06517c)
![image](https://github.com/iDvel/rime-ice/assets/32760059/0df11db8-4631-4387-a0ac-0b54cb4df881)
