### PR TITLE
fix: add double_pinyin_sogou.schema.yaml to install files

### DIFF
--- a/others/recipes/full.recipe.yaml
+++ b/others/recipes/full.recipe.yaml
@@ -20,6 +20,7 @@ install_files: >-
   double_pinyin.schema.yaml
   double_pinyin_abc.schema.yaml
   double_pinyin_mspy.schema.yaml
+  double_pinyin_sogou.schema.yaml
   double_pinyin_flypy.schema.yaml
   double_pinyin_ziguang.schema.yaml
   symbols_v.yaml


### PR DESCRIPTION
Otherwise the double_pinyin_sogou.schema.yaml is not downloaded but used in default.yaml and deploying will be failed.