### PR TITLE
fix: 瞓 shui -> fen

### DIFF
--- a/cn_dicts/41448.dict.yaml
+++ b/cn_dicts/41448.dict.yaml
@@ -7744,6 +7744,7 @@ sort: by_weight
 𩰟	fen
 𩸂	fen
 𩿈	fen
+瞓	fen
 㐽	feng
 㒥	feng
 㛔	feng
@@ -27659,7 +27660,6 @@ sort: by_weight
 涗	shui
 涚	shui
 睡	shui
-瞓	shui
 祱	shui
 稅	shui
 税	shui


### PR DESCRIPTION
修改大字表 41448.dict.yaml 中 "瞓" 的拼音
来源: https://zh.wiktionary.org/zh-hans/%E7%9E%93