### PR TITLE
use fullwidth 'A' for ascii_mode switches

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -33,7 +33,7 @@ schema:
 # reset: 默认状态。 注释掉后，切换窗口时不会重置到默认状态。
 switches:
   - name: ascii_mode
-    states: [ 中, A ]
+    states: [ 中, Ａ ]
     reset: 0
   - name: ascii_punct # 中英标点
     states: [ ¥, $ ]

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -33,7 +33,7 @@ schema:
 # reset: 默认状态。 注释掉后，切换窗口时不会重置到默认状态。
 switches:
   - name: ascii_mode
-    states: [ 中, A ]
+    states: [ 中, Ａ ]
     reset: 0
   - name: ascii_punct # 中英标点
     states: [ ¥, $ ]

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -33,7 +33,7 @@ schema:
 # reset: 默认状态。 注释掉后，切换窗口时不会重置到默认状态。
 switches:
   - name: ascii_mode
-    states: [ 中, A ]
+    states: [ 中, Ａ ]
     reset: 0
   - name: ascii_punct # 中英标点
     states: [ ¥, $ ]

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -33,7 +33,7 @@ schema:
 # reset: 默认状态。 注释掉后，切换窗口时不会重置到默认状态。
 switches:
   - name: ascii_mode
-    states: [ 中, A ]
+    states: [ 中, Ａ ]
     reset: 0
   - name: ascii_punct # 中英标点
     states: [ ¥, $ ]

--- a/double_pinyin_sogou.schema.yaml
+++ b/double_pinyin_sogou.schema.yaml
@@ -33,7 +33,7 @@ schema:
 # reset: 默认状态。 注释掉后，切换窗口时不会重置到默认状态。
 switches:
   - name: ascii_mode
-    states: [ 中, A ]
+    states: [ 中, Ａ ]
     reset: 0
   - name: ascii_punct # 中英标点
     states: [ ¥, $ ]

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -33,7 +33,7 @@ schema:
 # reset: 默认状态。 注释掉后，切换窗口时不会重置到默认状态。
 switches:
   - name: ascii_mode
-    states: [ 中, A ]
+    states: [ 中, Ａ ]
     reset: 0
   - name: ascii_punct # 中英标点
     states: [ ¥, $ ]

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -23,7 +23,7 @@ schema:
 # reset: 默认状态。 注释掉后，切换窗口时不会重置到默认状态。
 switches:
   - name: ascii_mode
-    states: [ 中, A ]
+    states: [ 中, Ａ ]
     reset: 0
   - name: ascii_punct # 中英标点
     states: [ ¥, $ ]


### PR DESCRIPTION
The width of the tooltip appears on switching CH/EN is inconsistent because '中' is wider than 'A'.

Solved by replacing 'A' with a fullwidth character 'Ａ'

Before:
<img width="153" alt="image" src="https://github.com/iDvel/rime-ice/assets/24245520/4b4a2c86-034f-4833-a211-7c57ed1a59f6">

After:
<img width="101" alt="image" src="https://github.com/iDvel/rime-ice/assets/24245520/6668167d-49cc-48b2-983c-eb2dd98ca955">
<img width="110" alt="image" src="https://github.com/iDvel/rime-ice/assets/24245520/bb968247-5709-4b04-adc6-03e1fad82aef">
