### PR TITLE
忽略sync目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode/
 
 build/
+sync/
 *.userdb/
 installation.yaml
 user.yaml


### PR DESCRIPTION
Linux下的fcitx5会产生一个sync目录，这个目录里面的文件是一些自动生成的文件，需要忽略。