### PR TITLE
feat: 自动按键转换；英文生词自动写入词典；辅助码 lua（无须额外码表，挂两分笔画）

### DIFF
--- a/lua/key_processor.lua
+++ b/lua/key_processor.lua
@@ -1,0 +1,273 @@
+-- key_processor.lua
+-- Copyright (C) Mirtle <mirtle.cn@outlook.com>
+-- Distributed under terms of the MIT license.
+
+KEYTABLE = {}
+COMMITHISTTORY = {}
+
+local P = {}
+
+-- 处理提供的规则，用了特殊符号搭桥
+local function c(s)
+    s = s:gsub("%%(%w)", '➋%1')
+    s = s:gsub("(%w)%-(%w)", "%1➌%2")
+    s = s:gsub("([%.%+%-%*%?%[%]%^%$%(%)%%])", "%%%1")
+    s = s:gsub([[\\]], [[/]])
+    s = s:gsub('➋', '%%')
+    s = s:gsub('➌', '-')
+    -- log.error(s)
+    return s
+end
+
+-- 提取规则中的文本
+local function r(s)
+    return s:gsub('^' .. '%%%%', ''):gsub(' %d+$', '')
+end
+
+-- 判断是否符合自定义规则
+local function r_match(str, pattern)
+    if pattern:find('^%%%%') then
+        return str:find("[" .. c(r(pattern)) .. "]$")
+    else
+        return str:find(c(r(pattern)) .. "$")
+    end
+    return false
+end
+
+-- 判断是否以中文结尾
+local function endsWithChinese(str)
+    -- 使用UTF-8编码，中文字符的最高位二进制表示是"110"
+    local pattern = "[\xe4-\xe9][\x80-\xbf]+$"
+    -- 使用string.match函数检查字符串是否以中文结尾
+    return string.match(str, pattern) ~= nil
+end
+
+-- 不处理的按键序列
+local function except(s)
+    if s:find("BackSpace%|BackSpace") then
+        return true
+    elseif s:find("Control%+a%|BackSpace") then
+        return true
+    end
+    return false
+end
+
+function P.init(env)
+    COMMITHISTTORY[1] = ''
+    KEYTABLE[0] = '-'
+    KEYTABLE[1] = '-'
+    KEYTABLE[2] = '-'
+    COMMITHISTTORY[0] = ''
+    KEYS = ''
+
+    local config = env.engine.schema.config
+    env.name_space = env.name_space:gsub("^*", "")
+    P.history_key = config:get_string(env.name_space .. '/commit_history_key')
+    -- P.search_key = config:get_string("key_binder/search") or config:get_string(env.name_space .. "/key") or '`'
+    P.debug = config:get_bool(env.name_space .. "/debug")
+
+    -- 当检测到此按键时，清空当前会话的提交历史记录
+    local key_list = config:get_list(env.name_space .. '/clear_history_key')
+    P.key_list = Set({"Up","Down","Escape","Shift+Return"})
+    if key_list then
+        for i = 0, key_list.size - 1 do
+            local k = key_list:get_value_at(i).value
+            if k then
+                P.key_list[k] = true
+            end
+        end
+    end
+
+    -- 中文后的符号转换规则，和 rime 的算法规则一致
+    local cn_rules = config:get_list(env.name_space .. '/cn_rules')
+    if cn_rules then
+        P.projection = Projection()
+        P.projection:load(cn_rules)
+    end
+
+    -- ascii/历史/按键/
+    local list = config:get_list(env.name_space .. '/ascii_rules')
+    if list then
+        P.ascii = {}
+        for i = 0, list.size - 1 do
+
+            local configString = list:get_value_at(i).value
+            local key, value = configString:match('^ascii/(.+)/(.+)/$')
+            if key and value then
+                key = c(key)
+                value = c(value)
+                P.ascii[key] = value
+            end
+        end
+    end
+
+    -- # fnr/历史字符/按键/上屏/
+    local c_rules = config:get_list(env.name_space .. '/custom_rules')
+    if c_rules then
+        -- 设置三个表，绕开 utf-8 处理的麻烦
+        P.c_rules_match = {}
+        P.c_rules = {}
+        P.match = '' -- 方便先匹配一次
+        for i = 0, c_rules.size - 1 do
+            local configString = c_rules:get_value_at(i).value
+            local m, k, v = configString:match('^fnr/(.+)/(.+)/(.+)/$')
+            if m and k and v then
+                m = m:gsub([[\\]], [[/]])
+                k = k:gsub([[\\]], [[/]])
+                v = v:gsub([[\\]], [[/]])
+                -- log.error( m .. k .. v)
+                P.match = P.match .. m:gsub('^%%%%', '')
+                m = m .. ' ' .. i -- 添加 i 以标记不同的规则
+                k = k .. ' ' .. i
+                P.c_rules_match[m] = k
+                P.c_rules[k] = v
+            end
+        end
+        P.match = '[' .. c(P.match) .. ']'
+        -- log.error(P.match)
+    end
+
+    -- 判断是否无规则
+    if not list and not cn_rules and c_rules then
+        P.no_rules = true
+    end
+end
+
+function P.func(key, env)
+    local context = env.engine.context
+    local latest_text = context.commit_history:latest_text()
+    -- 获取当前的 key 所代表的符号
+    local ascii_str = ''
+    if key.keycode > 0x20 and key.keycode < 0x7f then
+        ascii_str = string.char(key.keycode)
+    end
+
+    -- 记录最近三个按键和两个提交记录，用于规避空格、退格清空历史
+    -- 作用为，按下退格后，仍使用退格前的提交判断
+    if not key:release() then
+        -- local Pattern = "%w%|BackSpace"
+        local Pattern = ".+%|BackSpace"
+        -- key|space|BackSpace
+        if KEYS:find("%|" .. Pattern .. "$") and not except(KEYS) then
+            latest_text = COMMITHISTTORY[1]
+        end
+
+        -- space|BackSpace|Shift+Shift_L：这是以 Shift 引导的按键
+        if KEYS:find("^" .. Pattern .. "%|Shift") and not except(KEYS) then
+            latest_text = COMMITHISTTORY[0]
+        end
+
+        COMMITHISTTORY[1] = COMMITHISTTORY[0] or ''
+        COMMITHISTTORY[0] = latest_text
+        KEYTABLE[2] = KEYTABLE[1] or '-' -- 赋值以规避 error log 的产生
+        KEYTABLE[1] = KEYTABLE[0] or '-'
+        KEYTABLE[0] = key:repr() or '-'
+        KEYS = KEYTABLE[2] .. '|' .. KEYTABLE[1] .. '|' .. KEYTABLE[0]
+
+        if P.debug then
+            -- log.warning('history Liter: ' .. context.commit_history:repr())
+            -- log.warning('latest_text: ' .. context.commit_history:latest_text())
+            log.warning('KEYS_sequence: ' .. KEYS)
+            log.warning('COMMITHISTTORY: ' .. COMMITHISTTORY[0] .. '|' .. COMMITHISTTORY[1])
+            -- log.warning('key_string: ' .. ascii_str)
+        end
+    end
+
+    -- 检测到相关按键，清空历史记录
+    if P.key_list and P.key_list[key:repr()] and not context:is_composing() then
+        context.commit_history:clear()
+    end
+
+    -- 按下特定按键后，历史记录上屏
+    if P.history_key then
+        if context.input:match("^" .. P.history_key .. '$') then
+            context:clear()
+            env.engine:commit_text(latest_text)
+            return 1
+        end
+    end
+
+    -- 这是配合辅助码反查使用的，只允许输入一个辅助码
+    -- if P.search_key then
+    --     if context.input:find("^[a-z;]+" .. P.search_key) and ascii_str == P.search_key then
+    --         return 1 -- 不处理
+    --     end
+    -- end
+
+    -- 下面开始处理按键规则
+    -- 不处理的情况
+    if context:is_composing() -- 正在编辑
+    or context:has_menu() -- 有菜单
+    or P.no_rules -- 不指定规则
+    or key:ctrl() or key:alt() or key:super() -- 按下 ctrl() alt() 或者 super()
+    or key:release() -- 释放事件不处理
+    -- or key.keycode < 0x21 -- 控制符号
+    -- or key.keycode > 0x7e -- 非字母符号区
+    or ascii_str == '' or (not latest_text) -- 无上一次输入
+    or (latest_text == '') -- 上一次输入未记住
+    or (latest_text:find("^%s+$")) -- 上一次输入了空字符串
+    then
+        return 2
+    end
+
+    -- log.error('A: ' .. latest_text .. ' B: ' .. ascii_str)
+    -- log.error('Key Liter: ' .. key:repr())
+    -- log.error('History Liter: ' .. context.commit_history:repr())
+
+    -- 首先处理自定义规则
+    if P.c_rules_match and P.c_rules and latest_text:find(P.match) then
+        for m, v in pairs(P.c_rules_match) do
+            if r_match(latest_text, m) and r_match(ascii_str, v) then
+                local str = P.c_rules[v]
+                if str:find('^%%%%1') then
+                    return 1 -- 禁用
+                elseif str:find('^%%%%0') then
+                    return 0 -- 停止处理，让系统处理
+                elseif str:find('^%%%%2') then
+                    return 2 -- 放行
+                else
+                    env.engine:commit_text(str)
+                    return 1
+                end
+            end
+        end
+    end
+
+    -- 处理中文规则：有相关规则；上一次以中文结尾；输入的为标点
+    if P.projection and endsWithChinese(latest_text) and not ascii_str:find("%w") then
+        -- log.error('key: ' .. ascii_str .. ' c: ' .. P.projection:apply(ascii_str))
+        local c = P.projection:apply(ascii_str)
+        if c and c ~= '' then
+            env.engine:commit_text(c)
+            return 1
+        end
+    end
+
+    -- 处理 ascii 规则
+    if not P.ascii then
+        return 2
+    end
+    for k, v in pairs(P.ascii) do
+        if latest_text:match("[" .. k .. "]$") and ascii_str:match("[" .. v .. "]") then
+            -- 一种解决办法，直接用 commit_text 方法
+            env.engine:commit_text(ascii_str)
+            return 1
+
+            -- 当 return 0 使用系统处理按键时
+            -- 含有 Shift 键的键顶掉历史，因而获取到的记录将为空，可以手动推进去
+            -- if ascii_str:find('[{(<>)}]') then
+            --     context.commit_history:push(env.engine.context.composition, ascii_str)
+            -- end
+            -- return 0
+        end
+    end
+    return 2
+end
+
+function P.fini(env)
+    -- 清空
+    KEYTABLE = {}
+    COMMITHISTTORY = {}
+end
+
+return P

--- a/lua/parrot_translator.lua
+++ b/lua/parrot_translator.lua
@@ -1,0 +1,185 @@
+-- parrot_translator.lua
+-- Copyright (C) Mirtle <mirtle.cn@outlook.com>
+-- Distributed under terms of the MIT license.
+
+-- 将此翻译器放在最后，让产生的候选排序在后面
+-- 请将 translator 中设定 initial_quality 为 1 以上
+
+-- memoryCallback
+local function memoryCallback(memory, commit)
+    for i, dictentry in ipairs(commit:get()) do
+        memory:update_userdict(dictentry, 1, "")
+    end
+    return true
+end
+
+-- 转义特殊字符
+local function alt_lua_punc(s)
+    if s then
+        return s:gsub("([%.%+%-%*%?%[%]%^%$%(%)%%])", "%%%1")
+    else
+        return ''
+    end
+end
+
+-- 主函数
+local echo = {}
+
+-- 读取设置
+-- parrot_translator:
+--     always_on: bool # 是否始终开启此翻译器
+--     remove_punct:   # 在编码中删除这些符号
+--     comment:        # 注释
+--     space_pattern:  # 用以替代空格的符号（特殊字符需要 % 转义）
+--     schema:         # 操作的方案（用户词典写入的方案）
+function echo.init(env)
+    local config = env.engine.schema.config
+    env.name_space = env.name_space:gsub("^*", "")
+
+    echo.always_on = config:get_bool(env.name_space .. "/always_on")
+    echo.remove_punct = alt_lua_punc(config:get_string(env.name_space .. "/remove_punct")) or ''
+    echo.comment = config:get_string(env.name_space .. "/comment") or '+'
+    echo.space_pattern = alt_lua_punc(config:get_string(env.name_space .. '/space_alt')) or '%.%.'
+    echo.skip_when_find = alt_lua_punc(config:get_string(env.name_space .. "/ignore_string")) or ''
+
+
+    local schema_name = config:get_string(env.name_space .. "/schema")
+    if schema_name then
+        env.mem = Memory(env.engine, Schema(schema_name))
+    else
+        env.mem = Memory(env.engine, env.engine.schema)
+    end
+    env.mem:memorize(function(commit)
+        memoryCallback(env.mem, commit)
+    end)
+
+    local list = config:get_list(env.name_space .. '/ignore_pattern')
+    if not list then return end
+    echo.ignore_pattern = {}
+    for i = 0, list.size - 1 do
+        local v = list:get_value_at(i).value
+        if v then
+            table.insert(echo.ignore_pattern, v)
+        end
+    end
+end
+
+function echo.change_inp(s)
+    s = s:gsub(echo.space_pattern, ' ')
+    return s:gsub('[%s' .. echo.remove_punct  .. ']', "")
+end
+
+function echo.get_match_input(s)
+    return s:gsub(echo.space_pattern, ' ')
+end
+
+function echo.if_skip_echo(s)
+    if s:find("^%p") then
+        return true -- 以标点开头
+    elseif (s:find("%p$")) then
+        return true -- 以标点结尾
+    elseif s:find("%d") then
+        return true -- 有数字
+    elseif echo.skip_when_find and echo.skip_when_find ~= '' and s:find("[" .. echo.skip_when_find .. "]" ) then
+        return true
+    elseif echo.ignore_pattern then
+        for i, v in ipairs(echo.ignore_pattern) do
+            if s:match(v) then
+                return true
+            end
+        end
+    else
+        return false
+    end
+end
+
+function echo.new_dictentry(text, code, cmt)
+    if not cmt then
+        cmt = echo.comment
+    end
+    local DictEntry = DictEntry()
+    DictEntry.text = text
+    DictEntry.custom_code = code .. ' '
+    DictEntry.comment = cmt
+    DictEntry.preedit = text
+    return DictEntry
+end
+
+function echo.func(inp, seg, env)
+    -- 总条件：在 ⌥Option 处或者 schema 设置开启造词
+    --   - name: parrot_translator
+    --     reset: 1
+    --     abbrev: [关, 开]
+    --     states: [造词关, 造词开]
+    local input_code = env.engine.context.input
+    local commit_text = env.engine.context:get_commit_text()
+    local is_open = env.engine.context:get_option('parrot_translator')
+    if commit_text ~= input_code then
+        return
+    end
+    if (not is_open) and (not echo.always_on) then
+        return
+    end
+
+    -- input 是去除空格和符号（用户指定的除外）的编码
+    local input = echo.change_inp(inp)
+    local match = echo.get_match_input(inp)
+
+    -- 如果含有空格替换符，检索用户词典，上屏含空格的词组
+    if not inp:find(echo.space_pattern) then
+        goto echo_phrase_with_space_done
+    end
+
+    if env.mem:user_lookup(input, true , 50) then
+        for entry in env.mem:iter_user() do
+            if entry.text:find( '^' .. match) then
+                entry.comment = ''
+                yield(Phrase(env.mem, "echo", seg.start, seg._end, entry):toCandidate())
+            end
+        end
+    end
+    if env.mem:dict_lookup(input, true, 100) then
+        for entry in env.mem:iter_dict() do
+            if entry.text:find( '^' .. match) then
+                entry.comment = ''
+                yield(Phrase(env.mem, "echo", seg.start, seg._end, entry):toCandidate())
+            end
+        end
+    end
+
+    ::echo_phrase_with_space_done::
+
+    -- 学舌功能：开始
+    -- inp 满足一定条件不学舌
+    if echo.if_skip_echo(inp) then
+        return
+    end
+
+    -- 如果主词典、用户词典没有，则造词
+    if 
+    -- (not env.mem:user_lookup(input, false)) and -- 用户词典找不到相关的词汇
+    (not env.mem:dict_lookup(inp, false, 1)) -- 主词典中无完全匹配
+    then
+        local candTable = {}
+        -- 第一优先级候选：仅替换空格的词
+        local dict = echo.new_dictentry(inp:gsub(echo.space_pattern, ' '), input)
+        table.insert(candTable, dict)
+        -- 第二优先级候选：自动加空格的词
+        if inp:find("%l%u+") then
+            local candText = inp:gsub(echo.space_pattern, ' '):gsub("(%l)(%u+)", "%1 %2"):gsub('  ', ' ')
+            local dict2 = echo.new_dictentry(candText, input)
+            table.insert(candTable, dict2)
+        end
+        -- 第三优先级候选：不做任何转化的词
+        if inp:find(echo.space_pattern) then
+            local dict3 = echo.new_dictentry(inp, input)
+            table.insert(candTable, dict3)
+        end
+        -- 上屏
+        for i, entry in ipairs(candTable) do
+            local ph = Phrase(env.mem, "echo", seg.start, seg._end, entry)
+            yield(ph:toCandidate())
+        end
+    end
+end
+return echo

--- a/lua/search.lua
+++ b/lua/search.lua
@@ -1,0 +1,256 @@
+-- search.lua
+-- Copyright (C) Mirtle <mirtle.cn@outlook.com>
+-- Distributed under terms of the MIT license.
+-- select_notifier 逻辑取自 AuxFilter
+
+-- 取中文字符的第一个 by ChatGPT
+local function getFirstChineseCharacter(str)
+    local index = 1
+    local byteCount = 0
+
+    while index <= #str do
+        local byte = string.byte(str, index)
+        local charLen = 1
+
+        if byte >= 0xC0 and byte <= 0xDF then
+            charLen = 2
+        elseif byte >= 0xE0 and byte <= 0xEF then
+            charLen = 3
+        elseif byte >= 0xF0 and byte <= 0xF7 then
+            charLen = 4
+        end
+
+        if charLen > 1 then
+            -- Found a multi-byte character
+            byteCount = byteCount + 1
+            if byteCount == 1 then
+                return string.sub(str, index, index + charLen - 1)
+            end
+        end
+
+        index = index + charLen
+    end
+
+    return nil -- No Chinese character found
+end
+
+local function alt_lua_punc(s)
+    if s then
+        return s:gsub("([%.%+%-%*%?%[%]%^%$%(%)%%])", "%%%1")
+    else
+        return ''
+    end
+end
+
+local f = {}
+
+-- 逻辑
+-- 当在 engine 出直接指定了 namespace 则使用该 namespace 进行 schema 匹配
+-- 当在 search_in_cand 节点下指定了 schema 和 db 则进行相应匹配
+-- 当该节点下 schema 为 0 或者 false，或者不存在时，不进行相应匹配
+
+function f.init(env)
+    local config = env.engine.schema.config
+    local ns = 'search'
+
+    f.schema = config:get_string( ns .. '/schema')
+    if f.schema == 'false' or f.schema == '0' then
+        goto checkdb
+    end
+    if not env.name_space:find('^%*') then
+        f.schema = env.name_space
+    end
+    if f.schema then
+        f.mem = Memory(env.engine, Schema(f.schema))
+    end
+    f.schema_search_limit = config:get_int( ns .. "/schema_search_limit") or 1000
+    ::checkdb::
+    f.db = config:get_list( ns .. '/db')
+    f.if_schema_lookup = false
+    f.if_reverse_lookup = false
+    if f.schema and f.mem then
+        f.if_schema_lookup = true
+        -- log.error('if_schema_lookup: ' .. 'true')
+    end
+    if f.db then
+        f.wildcard = config:get_string(ns .. "/wildcard")
+        f.if_reverse_lookup = true
+        -- log.error('if_reverse_lookup: ' .. 'true')
+    end
+
+    -- 反引号作为查找的引导符号，需要加入 speller 的字母表当中 
+    f.search_key = config:get_string("key_binder/search") or config:get_string( ns .. "/key") or '`'
+
+    -- 处理一下输入码，如果还有没有上屏的词，保留辅助码，否则，清除上屏码
+    f.search_key_string = alt_lua_punc(f.search_key)
+
+    -- 如果不使用任何反查手段，则不接管选词逻辑
+    if not f.if_reverse_lookup and not f.if_schema_lookup then
+        return
+    end
+
+    -- 接管选词逻辑，是词组则始终保留引导码，否则直接上屏
+    env.notifier = env.engine.context.select_notifier:connect(function(ctx)
+        if not ctx.input:find("^[a-z;]+" .. f.search_key_string) then
+            return
+        end
+        local preedit = ctx:get_preedit()
+        local no_search_string = ctx.input:match("^(.-)" .. f.search_key_string)
+        -- log.warning('[no_search_string]: '..no_search_string)
+        local edit = preedit.text:match('^(.-)' .. f.search_key_string)
+        -- log.warning('[edit]: ' .. edit)
+
+        ctx.input = no_search_string
+
+        if edit and edit:match('[a-z;]') then
+            ctx.input = ctx.input .. f.search_key
+        else
+            ctx:commit()
+        end
+    end)
+
+end
+
+-- 查询反查词典当中的匹配项，并且返回字表
+function f.dict_init(search_string)
+    local dict_table = {}
+    if f.mem:dict_lookup(search_string, true, f.schema_search_limit) then
+        for entry in f.mem:iter_dict() do
+            -- log.error('text: ' .. entry.text .. ' code: ' .. entry.comment)
+            -- table.insert(dict_table, entry.text)
+            dict_table[entry.text] = true
+            -- dict_table[entry.text] = entry.comment
+        end
+    end
+    return dict_table
+end
+
+-- 通过 schema 的方式查询（以码查字，然后轮询匹配，非常慢，但能够匹配到算法转换过的码）
+function f.dict_match(table, text)
+    -- for i, dict in ipairs(table) do
+    --     if text == dict then
+    --         return true
+    --     end
+    -- end
+    if table[text] == true then
+        return true
+    end
+    return false
+end
+
+-- 通过 reverse db 查询（以字查码，然后比对辅码是否相同，比校快，但只能匹配未经算法转换的码）
+function f.reverse_lookup(text, s)
+    local list = f.db
+    s = s:gsub(f.wildcard,'.*')
+    -- log.error(s)
+    for i = 0, list.size - 1 do
+        local code = ReverseLookup(list:get_value_at(i).value):lookup(text)
+        if code:find(' ' .. s) or code:find('^' .. s) then
+            return true
+        end
+    end
+    return false
+end
+
+function f.func(input, env)
+    local input_code = env.engine.context.input
+    -- 当且仅当当输入码中含有辅码引导符号，并有有辅码存在，进入匹配逻辑
+    -- 当无任何查询方式存在，直接上屏
+    if
+        (input_code:find("^[a-z;]+" .. f.search_key_string .. '.+$'))
+        and (f.if_reverse_lookup or f.if_schema_lookup)
+    then
+        f.search_string = input_code:match("^.*" .. f.search_key_string .. "(.*)$")
+    else
+        for cand in input:iter() do
+            yield(cand)
+        end
+        return
+    end
+
+    -- 查字时是否单字优先
+    local if_single_char_first = env.engine.context:get_option("single_char")
+
+    local dict_table
+    if f.if_schema_lookup then
+        dict_table = f.dict_init(f.search_string)
+    end
+
+    local other_cand = {}
+    local other_cand_last = {}
+
+    for cand in input:iter() do
+        local type = cand.type -- 类型
+        local text = cand.text -- 候选文字
+        local comment = cand.comment
+        if utf8.len(text) > 1 and if_single_char_first then
+            table.insert(other_cand_last, cand)
+            goto skip
+        end
+
+        -- 处理经过 simplify 转化过的候选，使之能够正确匹配
+        if cand:get_dynamic_type() == "Shadow" then
+            local originalCand = cand:get_genuine()
+            cand = ShadowCandidate(originalCand, originalCand.type, cand.text, cand.comment)
+            type = cand.type
+            text = cand.text
+        end
+
+        -- 只有 script_translator 下的用户词和词才去匹配
+        if (type == 'phrase' or type == 'user_phrase') then
+            -- 当候选多于一个汉字，则取第一个匹配
+            if utf8.len(text) > 1 then
+                text = getFirstChineseCharacter(text)
+            end
+        else
+            table.insert(other_cand, cand)
+            goto skip
+        end
+
+        -- 匹配逻辑
+        local match = false
+        if f.if_schema_lookup then
+            match = f.dict_match(dict_table, text)
+            if match then
+                yield(cand)
+                goto skip
+            end
+        end
+
+        -- 支持同时指定 schema 查询和 reverse 查询
+        if f.if_reverse_lookup then
+            match = f.reverse_lookup(text, f.search_string)
+            if match then
+                yield(cand)
+                goto skip
+            end
+        end
+
+        -- 上屏匹配的候选和插入其余的候选
+        if match then
+            yield(cand)
+        else
+            table.insert(other_cand, cand)
+        end
+
+        ::skip::
+    end
+    -- 上屏其余的候选
+    for i, cand in ipairs(other_cand) do
+        yield(cand)
+    end
+
+    for i, cand in ipairs(other_cand_last) do
+        yield(cand)
+    end
+end
+
+function f.fini(env)
+    if not f.if_reverse_lookup and not f.if_schema_lookup then
+        return
+    end
+    env.notifier:disconnect()
+    -- env.commit_notifier:disconnect()
+end
+
+return f

--- a/rime.lua
+++ b/rime.lua
@@ -24,6 +24,9 @@ unicode = require("unicode")
 -- 数字、人民币大写，R 开头
 number_translator = require("number_translator")
 
+-- 无对应词典时，英文生词造词并写入用户词典（需要打开 user_dict）
+parrort_translator = require("parrort_translator")
+
 -- filters:
 
 -- 错音错字提示

--- a/rime.lua
+++ b/rime.lua
@@ -6,6 +6,10 @@
 -- 以词定字，可在 default.yaml → key_binder 下配置快捷键，默认为左右中括号 [ ]
 select_character = require("select_character")
 
+-- 按键处理，将指定字符后的指定按键替换为相应文本。
+-- 用例：自动 ascii 符号；数字后自动英文；中文符号匹配
+key_processor = require("key_processor")
+
 -- translators:
 
 -- 日期时间，可在方案中配置触发关键字。
@@ -31,6 +35,9 @@ v_filter = require("v_filter")
 
 -- 自动大写英文词汇
 autocap_filter = require("autocap_filter")
+
+-- 辅助码（在候选中使用笔画、两分等方式搜索）
+search = require("search")
 
 -- 降低部分英语单词在候选项的位置，可在方案中配置要降低的模式和单词
 reduce_english_filter = require("reduce_english_filter")


### PR DESCRIPTION
### 自动按键转换：如果上屏了指定字符，将该字符后的某个按键替换为某个内容

效果：
- 数字、英文后自动 ascii 符号；
- 中文后输入符号自动匹配相应符号
- 数字后自动键入英文

https://github.com/iDvel/rime-ice/assets/76689045/91a9c8b8-22ef-4f8b-a8f9-068d7631859f

配置
```yaml
key_processor:
  commit_history_key: '`t' # 按下此键直接上屏上一次的输入
  clear_history_key:
  # 检测到此键（不影响该键功能），清空当前会话（进程）的历史提交记录
  # rime 中，空格、退格等按键都会清空历史提交记录
  # 脚本添加了 Escape，Up，Down 以及 Shift + Return 键清空记录
  # 该选项的用例：将其设置为启动器（launcher）的快捷键，每触发一次都会重置输入状态

  # 以下三个规则：
  # 处理 [ASCII 码表](https://zh.wikipedia.org/wiki/ASCII) 0x21-0x7e 字符（**不包含空格**）
  # 两个反斜杠代替斜杠（ \\ -> /）
  # 百分号开头的特殊符号参考 <https://www.lua.org/pil/20.2.html>
  ascii_rules:
    # - ascii/历史/按键/
    # 上一次上屏词结尾是 A 字符，则将要输入的 B 字符将以 ASCII 码形式直接上屏
    - ascii/\\/\\/
    - ascii/`/`/
    - ascii/%d/,-:+*\\%a/
    - ascii/././
    - ascii/+-/+-/
    - ascii/_/_/
    - ascii/:/\\/
    - ascii/'"/'"])>}/
    - ascii/:_`+,-\\./%a/
    - ascii/%a/([<{:_`+-\\.'"%a/
    - ascii/!/[/
    - ascii/[]/%w[]()'"/
    - ascii/(/%w)[]'"/
    - ascii/</%w>'"/
    - ascii/{}/%w{}'"/
  cn_rules:
    # 中文后的符号转换规则，和 rime 的算法规则一致
    - xlit/.,?!:;|[<{(\/。，？！：；·「《『（、/
    - xform _ —— 
    - xform \^ ……
  custom_rules:
    # 优先级最高，最先处理
    # fnr/历史字符/按键字符/上屏字符/
    # 历史、按键字符前加 %% 为字符集匹配
    # 上屏字符为 %%1 -> 禁用此按键
    # 上屏字符为 %%2 -> 放行此按键
    # 上屏字符为 %%0 -> 系统处理按键
    # <https://github.com/hchunhui/librime-lua/wiki/Scripting#lua_processor>
    - fnr/「/]/」/
    - fnr/『/}/』/
    - fnr/（/)/）/
    - fnr/!/[/[]()/
    - fnr/《/>/》/
    - fnr/〈/>/〉/
    - fnr/：/[/「/
    - fnr/：/"/“”/
    - fnr/：/{/『/
    - fnr/：/'/‘’/
    - fnr/【/]/】/
    - fnr/〖/}/〗/
    - fnr/“/]/”/
    - fnr/‘/}/’/
```
### 英文生词入词典

![image](https://github.com/iDvel/rime-ice/assets/76689045/f2d21144-285c-401b-b4b7-e14f8d5e0e5a)
![image](https://github.com/iDvel/rime-ice/assets/76689045/3dee7f1c-cfc3-4fd4-9aa9-2ba49bfde4dd)

```yaml
  - name: parrot_translator
    # reset: 1
    abbrev: [关, 开]
    states: [造词关, 造词开]
parrot_translator:
  schema: melt_eng
  remove_punct: "."
  always_on: false
  space_alt: ".."
  comment: "+"
  ignore_string: "`:~"
  ignore_pattern:
    - "%w+%.%w+"
```

### 辅助码：
效果
![fuma](https://github.com/iDvel/rime-ice/assets/76689045/f0f4a2fd-b37a-46f7-8cf2-7b45687c7b73)

配置：
```yaml
search:
  # schema: radical_pinyin # 方案反查，建议小词库使用；
  # 大词库（table.bin 和 prism.bin 大小超过 1MB ）指定合理的搜索条目限制，否则会非常卡
  # schema_search_limit: 500 # 方案反查条目限制，越大越精确越卡，设为 0 无任何限制
  wildcard: "'" # 仅支持 db 反查，该按键需要加入 alphabet 中
  db: # 数据库反查，一个列表写一个，为 build 目录下 reverse.bin 前面的名字（一般为方案所用词典的词典名）
    - stroke
    - radical_pinyin_flypy
key_binder:
  search: "`" # 该按键需要加入 alphabet 中
```