### PR TITLE
增加一个hexo博客格式的datetime的类型

### DIFF
--- a/lua/date_translator.lua
+++ b/lua/date_translator.lua
@@ -47,6 +47,7 @@ function M.func(input, seg, env)
     -- ISO 8601/RFC 3339 的时间格式 （固定东八区）（示例 2022-01-07T20:42:51+08:00）
     elseif (input == M.datetime) then
         local current_time = os.time()
+        yield_cand(seg, os.date('%Y-%m-%d %H:%M:%S', current_time))
         yield_cand(seg, os.date('%Y-%m-%dT%H:%M:%S+08:00', current_time))
         yield_cand(seg, os.date('%Y%m%d%H%M%S', current_time))
 


### PR DESCRIPTION
当输入datetime的时候，可以打出`2024-02-27 19:24:02`类似这样的一个格式。这在hexo博客头文件的`yaml`中尤其有用。

在datetime下加了一行这样的一句话：
`yield_cand(seg, os.date('%Y-%m-%d %H:%M:%S', current_time))`