### PR TITLE
refactor: 更简洁的双拼算法

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -309,30 +309,30 @@ speller:
     - derive/^([jqxy])u$/$1v/
     - derive/^([aoe])([ioun])$/$1$1$2/
     - xform/^([aoe])(ng)?$/$1$1$2/
-    - xform/iu$/Ⓠ/
-    - xform/[iu]a$/Ⓦ/
-    - xform/[uv]an$/Ⓡ/
-    - xform/[uv]e$/Ⓣ/
-    - xform/ing$|uai$/Ⓨ/
-    - xform/^sh/Ⓤ/
-    - xform/^ch/Ⓘ/
-    - xform/^zh/Ⓥ/
-    - xform/uo$/Ⓞ/
-    - xform/[uv]n$/Ⓟ/
-    - xform/(.)i?ong$/$1Ⓢ/
-    - xform/[iu]ang$/Ⓓ/
-    - xform/(.)en$/$1Ⓕ/
-    - xform/(.)eng$/$1Ⓖ/
-    - xform/(.)ang$/$1Ⓗ/
-    - xform/ian$/Ⓜ/
-    - xform/(.)an$/$1Ⓙ/
-    - xform/iao$/Ⓒ/
-    - xform/(.)ao$/$1Ⓚ/
-    - xform/(.)ai$/$1Ⓛ/
-    - xform/(.)ei$/$1Ⓩ/
-    - xform/ie$/Ⓧ/
-    - xform/ui$/Ⓥ/
-    - xform/(.)ou$/$1Ⓑ/
-    - xform/in$/Ⓝ/
-    - xlit/ⓆⓌⓇⓉⓎⓊⒾⓄⓅⓈⒹⒻⒼⒽⓂⒿⒸⓀⓁⓏⓍⓋⒷⓃ/qwrtyuiopsdfghmjcklzxvbn/
+    - xform/iu$/<q>/
+    - xform/[iu]a$/<w>/
+    - xform/[uv]an$/<r>/
+    - xform/[uv]e$/<t>/
+    - xform/ing$|uai$/<y>/
+    - xform/^sh/<u>/
+    - xform/^ch/<i>/
+    - xform/^zh/<v>/
+    - xform/uo$/<o>/
+    - xform/[uv]n$/<p>/
+    - xform/(.)i?ong$/$1<s>/
+    - xform/[iu]ang$/<d>/
+    - xform/(.)en$/$1<f>/
+    - xform/(.)eng$/$1<g>/
+    - xform/(.)ang$/$1<h>/
+    - xform/ian$/<m>/
+    - xform/(.)an$/$1<j>/
+    - xform/iao$/<c>/
+    - xform/(.)ao$/$1<k>/
+    - xform/(.)ai$/$1<l>/
+    - xform/(.)ei$/$1<z>/
+    - xform/ie$/<x>/
+    - xform/ui$/<v>/
+    - xform/(.)ou$/$1<b>/
+    - xform/in$/<n>/
+    - xform/<|>/
     # - abbrev/^(.).+$/$1/  # 首字母简拼，开启后会导致 3 个字母时 kj'x 变成 k'jx 的问题

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -309,30 +309,30 @@ speller:
   delimiter: " '"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     - erase/^xx$/
-    - xform/^zh/Ⓐ/
-    - xform/^ch/Ⓔ/
-    - xform/^sh/Ⓥ/
-    - xform/^([aoe].*)$/Ⓞ$1/
-    - xform/ei$/Ⓠ/
-    - xform/ian$/Ⓦ/
-    - xform/er$|iu$/Ⓡ/
-    - xform/[iu]ang$/Ⓣ/
-    - xform/ing$/Ⓨ/
-    - xform/uo$/Ⓞ/
-    - xform/uan$/Ⓟ/
-    - xform/(.)i?ong$/$1Ⓢ/
-    - xform/[iu]a$/Ⓓ/
-    - xform/en$/Ⓕ/
-    - xform/eng$/Ⓖ/
-    - xform/ang$/Ⓗ/
-    - xform/an$/Ⓙ/
-    - xform/iao$/Ⓩ/
-    - xform/ao$/Ⓚ/
-    - xform/in$|uai$/Ⓒ/
-    - xform/ai$/Ⓛ/
-    - xform/ie$/Ⓧ/
-    - xform/ou$/Ⓑ/
-    - xform/un$/Ⓝ/
-    - xform/[uv]e$|ui$/Ⓜ/
-    - xlit/ⓆⓌⒺⓇⓉⓎⓄⓅⒶⓈⒹⒻⒼⒽⒿⓀⓁⓏⓍⒸⓋⒷⓃⓂ/qwertyopasdfghjklzxcvbnm/
+    - xform/^zh/<a>/
+    - xform/^ch/<e>/
+    - xform/^sh/<v>/
+    - xform/^([aoe].*)$/<o>$1/
+    - xform/ei$/<q>/
+    - xform/ian$/<w>/
+    - xform/er$|iu$/<r>/
+    - xform/[iu]ang$/<t>/
+    - xform/ing$/<y>/
+    - xform/uo$/<o>/
+    - xform/uan$/<p>/
+    - xform/(.)i?ong$/$1<s>/
+    - xform/[iu]a$/<d>/
+    - xform/en$/<f>/
+    - xform/eng$/<g>/
+    - xform/ang$/<h>/
+    - xform/an$/<j>/
+    - xform/iao$/<z>/
+    - xform/ao$/<k>/
+    - xform/in$|uai$/<c>/
+    - xform/ai$/<l>/
+    - xform/ie$/<x>/
+    - xform/ou$/<b>/
+    - xform/un$/<n>/
+    - xform/[uv]e$|ui$/<m>/
+    - xform/<|>/
     # - abbrev/^(.).+$/$1/  # 首字母简拼，开启后会导致 3 个字母时 kj'x 变成 k'jx 的问题

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -309,30 +309,30 @@ speller:
     - derive/^([jqxy])u$/$1v/
     - derive/^([aoe])([ioun])$/$1$1$2/
     - xform/^([aoe])(ng)?$/$1$1$2/
-    - xform/iu$/Ⓠ/
-    - xform/(.)ei$/$1Ⓦ/
-    - xform/uan$/Ⓡ/
-    - xform/[uv]e$/Ⓣ/
-    - xform/un$/Ⓨ/
-    - xform/^sh/Ⓤ/
-    - xform/^ch/Ⓘ/
-    - xform/^zh/Ⓥ/
-    - xform/uo$/Ⓞ/
-    - xform/ie$/Ⓟ/
-    - xform/(.)i?ong$/$1Ⓢ/
-    - xform/ing$|uai$/Ⓚ/
-    - xform/(.)ai$/$1Ⓓ/
-    - xform/(.)en$/$1Ⓕ/
-    - xform/(.)eng$/$1Ⓖ/
-    - xform/[iu]ang$/Ⓛ/
-    - xform/(.)ang$/$1Ⓗ/
-    - xform/ian$/Ⓜ/
-    - xform/(.)an$/$1Ⓙ/
-    - xform/(.)ou$/$1Ⓩ/
-    - xform/[iu]a$/Ⓧ/
-    - xform/iao$/Ⓝ/
-    - xform/(.)ao$/$1Ⓒ/
-    - xform/ui$/Ⓥ/
-    - xform/in$/Ⓑ/
-    - xlit/ⓆⓌⓇⓉⓎⓊⒾⓄⓅⓈⒹⒻⒼⒽⒿⓀⓁⓏⓍⒸⓋⒷⓃⓂ/qwrtyuiopsdfghjklzxcvbnm/
+    - xform/iu$/<q>/
+    - xform/(.)ei$/$1<w>/
+    - xform/uan$/<r>/
+    - xform/[uv]e$/<t>/
+    - xform/un$/<y>/
+    - xform/^sh/<u>/
+    - xform/^ch/<i>/
+    - xform/^zh/<v>/
+    - xform/uo$/<o>/
+    - xform/ie$/<p>/
+    - xform/(.)i?ong$/$1<s>/
+    - xform/ing$|uai$/<k>/
+    - xform/(.)ai$/$1<d>/
+    - xform/(.)en$/$1<f>/
+    - xform/(.)eng$/$1<g>/
+    - xform/[iu]ang$/<l>/
+    - xform/(.)ang$/$1<h>/
+    - xform/ian$/<m>/
+    - xform/(.)an$/$1<j>/
+    - xform/(.)ou$/$1<z>/
+    - xform/[iu]a$/<x>/
+    - xform/iao$/<n>/
+    - xform/(.)ao$/$1<c>/
+    - xform/ui$/<v>/
+    - xform/in$/<b>/
+    - xform/<|>/
     # - abbrev/^(.).+$/$1/  # 首字母简拼，开启后会导致 3 个字母时 kj'x 变成 k'jx 的问题

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -313,32 +313,32 @@ speller:
     - derive/^([jqxy])u$/$1v/
     - derive/^([aoe].*)$/o$1/
     - xform/^([ae])(.*)$/$1$1$2/
-    - xform/iu$/Ⓠ/
-    - xform/[iu]a$/Ⓦ/
-    - xform/er$|[uv]an$/Ⓡ/
-    - xform/[uv]e$/Ⓣ/
-    - xform/v$|uai$/Ⓨ/
-    - xform/^sh/Ⓤ/
-    - xform/^ch/Ⓘ/
-    - xform/^zh/Ⓥ/
-    - xform/uo$/Ⓞ/
-    - xform/[uv]n$/Ⓟ/
-    - xform/(.)i?ong$/$1Ⓢ/
-    - xform/[iu]ang$/Ⓓ/
-    - xform/(.)en$/$1Ⓕ/
-    - xform/(.)eng$/$1Ⓖ/
-    - xform/(.)ang$/$1Ⓗ/
-    - xform/ian$/Ⓜ/
-    - xform/(.)an$/$1Ⓙ/
-    - xform/iao$/Ⓒ/
-    - xform/(.)ao$/$1Ⓚ/
-    - xform/(.)ai$/$1Ⓛ/
-    - xform/(.)ei$/$1Ⓩ/
-    - xform/ie$/Ⓧ/
-    - xform/ui$/Ⓥ/
-    - derive/Ⓣ$/Ⓥ/
-    - xform/(.)ou$/$1Ⓑ/
-    - xform/in$/Ⓝ/
+    - xform/iu$/<q>/
+    - xform/[iu]a$/<w>/
+    - xform/er$|[uv]an$/<r>/
+    - xform/[uv]e$/<t>/
+    - xform/v$|uai$/<y>/
+    - xform/^sh/<u>/
+    - xform/^ch/<i>/
+    - xform/^zh/<v>/
+    - xform/uo$/<o>/
+    - xform/[uv]n$/<p>/
+    - xform/(.)i?ong$/$1<s>/
+    - xform/[iu]ang$/<d>/
+    - xform/(.)en$/$1<f>/
+    - xform/(.)eng$/$1<g>/
+    - xform/(.)ang$/$1<h>/
+    - xform/ian$/<m>/
+    - xform/(.)an$/$1<j>/
+    - xform/iao$/<c>/
+    - xform/(.)ao$/$1<k>/
+    - xform/(.)ai$/$1<l>/
+    - xform/(.)ei$/$1<z>/
+    - xform/ie$/<x>/
+    - xform/ui$/<v>/
+    - derive/<t>$/<v>/
+    - xform/(.)ou$/$1<b>/
+    - xform/in$/<n>/
     - xform/ing$/;/
-    - xlit/ⓆⓌⓇⓉⓎⓊⒾⓄⓅⓈⒹⒻⒼⒽⓂⒿⒸⓀⓁⓏⓍⓋⒷⓃ/qwrtyuiopsdfghmjcklzxvbn/
+    - xform/<|>/
     # - abbrev/^(.).+$/$1/  # 首字母简拼，开启后会导致 3 个字母时 kj'x 变成 k'jx 的问题

--- a/double_pinyin_sogou.schema.yaml
+++ b/double_pinyin_sogou.schema.yaml
@@ -313,31 +313,31 @@ speller:
     - derive/^([jqxy])u$/$1v/
     - derive/^([aoe].*)$/o$1/
     - xform/^([ae])(.*)$/$1$1$2/
-    - xform/iu$/Ⓠ/
-    - xform/[iu]a$/Ⓦ/
-    - xform/er$|[uv]an$/Ⓡ/
-    - xform/[uv]e$/Ⓣ/
-    - xform/v$|uai$/Ⓨ/
-    - xform/^sh/Ⓤ/
-    - xform/^ch/Ⓘ/
-    - xform/^zh/Ⓥ/
-    - xform/uo$/Ⓞ/
-    - xform/[uv]n$/Ⓟ/
-    - xform/(.)i?ong$/$1Ⓢ/
-    - xform/[iu]ang$/Ⓓ/
-    - xform/(.)en$/$1Ⓕ/
-    - xform/(.)eng$/$1Ⓖ/
-    - xform/(.)ang$/$1Ⓗ/
-    - xform/ian$/Ⓜ/
-    - xform/(.)an$/$1Ⓙ/
-    - xform/iao$/Ⓒ/
-    - xform/(.)ao$/$1Ⓚ/
-    - xform/(.)ai$/$1Ⓛ/
-    - xform/(.)ei$/$1Ⓩ/
-    - xform/ie$/Ⓧ/
-    - xform/ui$/Ⓥ/
-    - xform/(.)ou$/$1Ⓑ/
-    - xform/in$/Ⓝ/
+    - xform/iu$/<q>/
+    - xform/[iu]a$/<w>/
+    - xform/er$|[uv]an$/<r>/
+    - xform/[uv]e$/<t>/
+    - xform/v$|uai$/<y>/
+    - xform/^sh/<u>/
+    - xform/^ch/<i>/
+    - xform/^zh/<v>/
+    - xform/uo$/<o>/
+    - xform/[uv]n$/<p>/
+    - xform/(.)i?ong$/$1<s>/
+    - xform/[iu]ang$/<d>/
+    - xform/(.)en$/$1<f>/
+    - xform/(.)eng$/$1<g>/
+    - xform/(.)ang$/$1<h>/
+    - xform/ian$/<m>/
+    - xform/(.)an$/$1<j>/
+    - xform/iao$/<c>/
+    - xform/(.)ao$/$1<k>/
+    - xform/(.)ai$/$1<l>/
+    - xform/(.)ei$/$1<z>/
+    - xform/ie$/<x>/
+    - xform/ui$/<v>/
+    - xform/(.)ou$/$1<b>/
+    - xform/in$/<n>/
     - xform/ing$/;/
-    - xlit/ⓆⓌⓇⓉⓎⓊⒾⓄⓅⓈⒹⒻⒼⒽⓂⒿⒸⓀⓁⓏⓍⓋⒷⓃ/qwrtyuiopsdfghmjcklzxvbn/
+    - xform/<|>/
     # - abbrev/^(.).+$/$1/  # 首字母简拼，开启后会导致 3 个字母时 kj'x 变成 k'jx 的问题

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -309,30 +309,30 @@ speller:
   algebra:
     - erase/^xx$/
     - derive/^([jqxy])u$/$1v/
-    - xform/^([aoe].*)$/Ⓞ$1/  # 添上固定的零聲母o，先標記爲大寫O
-    - xform/en$/Ⓦ/
-    - xform/eng$/Ⓣ/
-    - xform/in$|uai$/Ⓨ/
-    - xform/^zh/Ⓤ/
-    - xform/^sh/Ⓘ/
-    - xform/uo$/Ⓞ/
-    - xform/ai$/Ⓟ/
-    - xform/^ch/Ⓐ/
-    - xform/[iu]ang$/Ⓖ/
-    - xform/ang$/Ⓢ/  # ang should be placed after iang/uang
-    - xform/ie$/Ⓓ/
-    - xform/ian$/Ⓕ/
-    - xform/(.)i?ong$/$1Ⓗ/
-    - xform/er$|iu$/Ⓙ/
-    - xform/ei$/Ⓚ/
-    - xform/uan$/Ⓛ/
+    - xform/^([aoe].*)$/<o>$1/  # 添上固定的零聲母o，先標記爲大寫O
+    - xform/en$/<w>/
+    - xform/eng$/<t>/
+    - xform/in$|uai$/<y>/
+    - xform/^zh/<u>/
+    - xform/^sh/<i>/
+    - xform/uo$/<o>/
+    - xform/ai$/<p>/
+    - xform/^ch/<a>/
+    - xform/[iu]ang$/<g>/
+    - xform/ang$/<s>/  # ang should be placed after iang/uang
+    - xform/ie$/<d>/
+    - xform/ian$/<f>/
+    - xform/(.)i?ong$/$1<h>/
+    - xform/er$|iu$/<j>/
+    - xform/ei$/<k>/
+    - xform/uan$/<l>/
     - xform/ing$/;/
-    - xform/ou$/Ⓩ/
-    - xform/[iu]a$/Ⓧ/
-    - xform/iao$/Ⓑ/
-    - xform/ue$|ui$|ve$/Ⓝ/
-    - xform/un$/Ⓜ/
-    - xform/ao$/Ⓠ/ # ao should be placed after iao
-    - xform/an$/Ⓡ/ # an should be placed after uan/ian
-    - xlit/ⓌⓉⓎⓊⒾⓄⓅⒶⒼⓈⒹⒻⒽⒿⓀⓁⓏⓍⒷⓃⓂⓆⓇ/wtyuiopagsdfhjklzxbnmqr/
+    - xform/ou$/<z>/
+    - xform/[iu]a$/<x>/
+    - xform/iao$/<b>/
+    - xform/ue$|ui$|ve$/<n>/
+    - xform/un$/<m>/
+    - xform/ao$/<q>/ # ao should be placed after iao
+    - xform/an$/<r>/ # an should be placed after uan/ian
+    - xform/<|>/
     # - abbrev/^(.).+$/$1/  # 首字母简拼，开启后会导致 3 个字母时 kj'x 变成 k'jx 的问题


### PR DESCRIPTION
https://github.com/rime/rime-double-pinyin/issues/13

好处：不再引入任何特殊字符；保持原有的功能
坏处：如果用 xform/©/un/ 这种方式在自定义文件定义过模糊音，可能需要修改算法

测试：

半年来我用着这一套小鹤的双拼算法，没有问题，其他双拼方案无条件测试。

radical_pinyin 用的是这套方案的变体。