### PR TITLE
fix: is_in_user_dict.lua 不处理滤镜产生的候选。

### DIFF
--- a/lua/is_in_user_dict.lua
+++ b/lua/is_in_user_dict.lua
@@ -17,8 +17,10 @@ local is_user = {
 
 function M.func(input)
     for cand in input:iter() do
-        if is_user[cand.type] == M.is_in_user_dict then
-            cand.comment = cand.comment .. '*'
+        if cand.text==cand:get_genuine().text then
+            if is_user[cand.type] == M.is_in_user_dict then
+                cand=ShadowCandidate(cand,"","",cand.comment.."*")
+            end
         end
         yield(cand)
     end


### PR DESCRIPTION
前：
![image](https://github.com/iDvel/rime-ice/assets/32760059/683ea1af-b1b7-43d5-9c23-522a78c664e5)

后：
![image](https://github.com/iDvel/rime-ice/assets/32760059/4e7ffc52-ea58-4ae0-a363-07217196a0e9)

原理为通过 get_genuine 方法获取候选原型，如果候选与原型的 text 属性不同，则认为这是一个滤镜产生的候选。