### PR TITLE
fix: T9方案输入无效

### DIFF
--- a/t9.schema.yaml
+++ b/t9.schema.yaml
@@ -84,6 +84,7 @@ key_binder:
 
 speller:
   alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA987654321
+  initials: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA987654321
   algebra:
     # 如果需要模糊音，可参考 rime_ice.schema.yaml 下的示例，放到最前面来就行，但不会正常显示模糊后的拼音。
     # - derive/^([zcs])h/$1/


### PR DESCRIPTION
Hello，商店 2.4.0 版本「仓输入法」上线后，发现九宫格输入法失效了。

对比发现是 rime_ice.schema.yaml 调整后（git commit id: 8fc6a6e87521465941aee4660eca4e4228119a67）的所产生的问题。

我这里测试发现 T9 方案同时增`initials`参数配置后，输入恢复正常。