### PR TITLE
dict: Add regular words and tech-related terms (nvm, ESLint, Prettier, etc.)

### DIFF
--- a/en_dicts/en.dict.yaml
+++ b/en_dicts/en.dict.yaml
@@ -4926,11 +4926,23 @@ decorating	decorating
 decoration	decoration
 decorations	decorations
 decorative	decorative
+decouple	decouple
+decoupled	decoupled
+decoupler	decoupler
+decouplers	decouplers
+decouples	decouples
+decoupling	decoupling
 decrease	decrease
 decreased	decreased
 decreases	decreases
 decreasing	decreasing
 decree	decree
+decried	decried
+decrier	decrier
+decriers	decriers
+decries	decries
+decry	decry
+decrying	decrying
 dedicate	dedicate
 dedicated	dedicated
 dedication	dedication
@@ -5061,6 +5073,12 @@ demonstrating	demonstrating
 demonstration	demonstration
 demonstrations	demonstrations
 demos	demos
+demote	demote
+demotes	demotes
+demoted	demoted
+demoting	demoting
+demotion	demotion
+demotions	demotions
 # dems	dems
 demux	demux
 den	den
@@ -5728,6 +5746,10 @@ dove	dove
 dover	dover
 # dow	dow
 down	down
+downgrade	downgrade
+downgraded	downgraded
+downgrades	downgrades
+downgrading	downgrading
 downhill	downhill
 downing	downing
 download	download
@@ -8769,6 +8791,11 @@ hey	hey
 # hhs	hhs
 hi	hi
 Hi-Fi	HiFi
+hibernate	hibernate
+hibernation	hibernation
+hibernations	hibernations
+hibernator	hibernator
+hibernators	hibernators
 hickory	hickory
 hicks	hicks
 hid	hid
@@ -17675,6 +17702,9 @@ sprout	sprout
 spruce	spruce
 spun	spun
 spur	spur
+spurious	spurious
+spuriously	spuriously
+spuriousness	spuriousness
 spurs	spurs
 spy	spy
 spying	spying

--- a/en_dicts/en_ext.dict.yaml
+++ b/en_dicts/en_ext.dict.yaml
@@ -1393,6 +1393,7 @@ refactoring	refactoring
 refactor	refactor
 Notepad	Notepad
 Notepad++	Notepad++
+Notepad++	npp
 O'Reilly	O'Reilly
 Octocat	Octocat
 IMAP	IMAP
@@ -2156,6 +2157,7 @@ pranksters	pranksters
 npm	npm
 Node Package Manager	npm
 Node Package Manager	NodePackageManager
+.npmrc	npmrc
 Apple Vision	AppleVision
 Apple Vision Pro	AppleVisionPro
 Vision Pro	VisionPro
@@ -2465,3 +2467,17 @@ trudge	trudge
 LibreOffice	LibreOffice
 Asics	Asics
 dubbing	dubbing
+nvm	nvm
+Node Version Manager	nvm
+Node Version Manager	NodeVersionManager
+Prettier	Prettier
+.prettierrc	prettierrc
+ESLint	ESLint
+eslint.config.js	eslintconfigjs
+.eslintrc.js	eslintrcjs
+Hibernate	Hibernate
+MyBatis	MyBatis
+MyBatis-Plus	MyBatisPlus
+Spring Boot	SpringBoot
+Spring Cloud	SpringCloud
+Element Plus	ElementPlus

--- a/en_dicts/en_ext.dict.yaml
+++ b/en_dicts/en_ext.dict.yaml
@@ -2462,7 +2462,6 @@ Theseus	Theseus
 Laravel	Laravel
 monolith	monolith
 Chiikawa	Chiikawa
-anxious	anxious
 trudge	trudge
 LibreOffice	LibreOffice
 Asics	Asics


### PR DESCRIPTION
hibernate既是常规单词，意为“冬眠”，又是编程术语，指代一种持久层框架。目前是同时保留两者，`hibernate`放在en.dict，`Hibernate`放在en_ext.dict。如果有更好的处理方式，烦请直接修改提交内容。