### PR TITLE
Update corrector.lua librime更新至 1.11.0 后，不显示联想词的注释

### DIFF
--- a/lua/corrector.lua
+++ b/lua/corrector.lua
@@ -116,7 +116,8 @@ function M.func(input)
         local c = M.corrections[cand.comment]
         if c and cand.text == c.text then
             cand:get_genuine().comment = string.gsub(M.style, "{comment}", c.comment)
-        elseif cand.type == "user_phrase" or cand.type == "phrase" or cand.type == "sentence" then
+        elseif cand.type == "user_phrase" or cand.type == "phrase" or cand.type == "sentence" or cand.type == "completion" then
+	    -- or cand.type == "completion" 清空了补全与联想的注释，如果需要，将其删去
             cand:get_genuine().comment = ""
         end
         yield(cand)


### PR DESCRIPTION
librime 更新至 1.11.0 后并（默认）启用联想功能后，不显示联想词的注释

可能会影响 #461

部分关联 issue #787