### PR TITLE
fix(lua): corrector.lua now clears specific cand.comment

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -161,6 +161,9 @@ translator:
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2          # 拼音的权重应该比英文大
+  comment_format:               # 标记拼音注释，供 corrector.lua 做判断用
+    - xform/^/［/
+    - xform/$/］/
   preedit_format:               # preedit_format 影响到输入框的显示和“Shift+回车”上屏的字符
     - xform/([bpmnljqxy])n/$1in/
     - xform/(\w)g/$1eng/

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -161,6 +161,9 @@ translator:
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2          # 拼音的权重应该比英文大
+  comment_format:               # 标记拼音注释，供 corrector.lua 做判断用
+    - xform/^/［/
+    - xform/$/］/
   preedit_format:               # preedit_format 影响到输入框的显示和“Shift+回车”上屏的字符
     - xform/o(\w)/0$1/
     - xform/(\w)q/$1ei/

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -161,6 +161,9 @@ translator:
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2          # 拼音的权重应该比英文大
+  comment_format:               # 标记拼音注释，供 corrector.lua 做判断用
+    - xform/^/［/
+    - xform/$/］/
   preedit_format:               # preedit_format 影响到输入框的显示和“Shift+回车”上屏的字符
     - xform/([bpmfdtnljqx])n/$1iao/
     - xform/(\w)g/$1eng/

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -161,6 +161,9 @@ translator:
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2          # 拼音的权重应该比英文大
+  comment_format:               # 标记拼音注释，供 corrector.lua 做判断用
+    - xform/^/［/
+    - xform/$/］/
   preedit_format:               # preedit_format 影响到输入框的显示和“Shift+回车”上屏的字符
     - xform/([aoe])(\w)/0$2/
     - xform/([bpmnljqxy])n/$1in/

--- a/double_pinyin_sogou.schema.yaml
+++ b/double_pinyin_sogou.schema.yaml
@@ -161,6 +161,9 @@ translator:
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2          # 拼音的权重应该比英文大
+  comment_format:               # 标记拼音注释，供 corrector.lua 做判断用
+    - xform/^/［/
+    - xform/$/］/
   preedit_format:               # preedit_format 影响到输入框的显示和“Shift+回车”上屏的字符
     - xform/([aoe])(\w)/0$2/
     - xform/([bpmnljqxy])n/$1in/

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -161,6 +161,9 @@ translator:
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2          # 拼音的权重应该比英文大
+  comment_format:               # 标记拼音注释，供 corrector.lua 做判断用
+    - xform/^/［/
+    - xform/$/］/
   preedit_format:               # preedit_format 影响到输入框的显示和“Shift+回车”上屏的字符
     - xform/o(\w)/0$1/              # 零聲母先改爲0，以方便後面的轉換
     - xform/([jqxy])n/$1ue/         # 提前轉換雙拼碼 n 和 g，因爲轉換後的拼音裏就快要出現這兩個字母了，那時將難以分辨出雙拼碼

--- a/lua/corrector.lua
+++ b/lua/corrector.lua
@@ -13,6 +13,10 @@ local M = {}
 
 function M.init(env)
     local config = env.engine.schema.config
+    local delimiter = config:get_string('speller/delimiter')
+    if delimiter and #delimiter > 0 and delimiter:sub(1,1) ~= ' ' then
+        env.delimiter = delimiter:sub(1,1)
+    end
     env.name_space = env.name_space:gsub('^*', '')
     M.style = config:get_string(env.name_space) or '{comment}'
     M.corrections = {
@@ -110,11 +114,14 @@ function M.init(env)
     }
 end
 
-function M.func(input)
+function M.func(input, env)
     for cand in input:iter() do
         -- cand.comment 是目前输入的词汇的完整拼音
         local pinyin = cand.comment:match("^［(.-)］$")
         if pinyin and #pinyin > 0 then
+            if env.delimiter then
+                pinyin = pinyin:gsub(env.delimiter,' ')
+            end
             local c = M.corrections[pinyin]
             if c and cand.text == c.text then
                 cand:get_genuine().comment = string.gsub(M.style, "{comment}", c.comment)

--- a/lua/corrector.lua
+++ b/lua/corrector.lua
@@ -113,11 +113,14 @@ end
 function M.func(input)
     for cand in input:iter() do
         -- cand.comment 是目前输入的词汇的完整拼音
-        local c = M.corrections[cand.comment]
-        if c and cand.text == c.text then
-            cand:get_genuine().comment = string.gsub(M.style, "{comment}", c.comment)
-        elseif cand.type == "user_phrase" or cand.type == "phrase" or cand.type == "sentence" then
-            cand:get_genuine().comment = ""
+        local pinyin = cand.comment:match("^［(.-)］$")
+        if pinyin and #pinyin > 0 then
+            local c = M.corrections[pinyin]
+            if c and cand.text == c.text then
+                cand:get_genuine().comment = string.gsub(M.style, "{comment}", c.comment)
+            else
+                cand:get_genuine().comment = ""
+            end
         end
         yield(cand)
     end

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -293,6 +293,9 @@ translator:
   spelling_hints: 8           # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true  # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2        # 拼音的权重应该比英文大
+  comment_format:             # 标记拼音注释，供 corrector.lua 做判断用
+    - xform/^/［/
+    - xform/$/］/
   preedit_format:             # preedit_format 影响到输入框的显示和“Shift+回车”上屏的字符
     - xform/([jqxy])v/$1u/    # 显示为 ju qu xu yu
     # - xform/([nl])v/$1ü/    # 显示为 nü lü


### PR DESCRIPTION
close #792 
close #787 

使用 comment_format 标记拼音注释。再清空，防止影响其他类型的注释。

标记用了一般不会出现的全角方括号。

cc @iDvel @luminosara