### PR TITLE
fix: 删除中文九宫格候选字 comment 信息前后的 [ ] 字符

### DIFF
--- a/t9.schema.yaml
+++ b/t9.schema.yaml
@@ -57,6 +57,7 @@ engine:
 translator:
   prism: t9
   spelling_hints: 100
+  comment_format: []
 
 
 # 自定义短语：custom_phrase_t9.txt


### PR DESCRIPTION
我看到提交：https://github.com/iDvel/rime-ice/commit/62f3e107a01a6f18a21fe29519a1f8542756d91d

本次提交会对对候选字 comment 做标记，前后都追加加 [] 符号，配置如下：

```yaml
  comment_format:             # 标记拼音注释，供 corrector.lua 做判断用
    - xform/^/［/
    - xform/$/］/
```

这会导致输入法前端对候选字 comment 做处理时有问题。

因此在 T9 方案的配置中对 comment_format 参数做了屏蔽。

最后建议调整下`corrector.lua` 脚本的逻辑：对 comment 信息处理完毕后，应删除标记 []，且不能将 comment 信息清空。

```lua
            if c and cand.text == c.text then
                cand:get_genuine().comment = string.gsub(M.style, "{comment}", c.comment)
            else
                cand:get_genuine().comment = "" -- 目前这里会对 comment 信息清空。建议这里删除追加的 [] 标记，并还原 comment 值。
            end
```