### PR TITLE
feat: Automate removal of duplicates within en_ext and against en

### DIFF
--- a/others/script/main.go
+++ b/others/script/main.go
@@ -64,7 +64,8 @@ SORT:
 	rime.Sort(rime.BasePath, 3)
 	rime.Sort(rime.ExtPath, 3)
 	rime.Sort(rime.TencentPath, 4)
-	rime.Sort(filepath.Join(rime.RimeDir, "en_dicts/en.dict.yaml"), 2)
+	rime.Sort(rime.EnPath, 2)
+	rime.Sort(rime.EnExtPath, 2)
 }
 
 func areYouOK() {

--- a/others/script/rime/rime.go
+++ b/others/script/rime/rime.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // 一个词的组成部分
@@ -18,6 +19,16 @@ type lemma struct {
 	text   string // 汉字
 	code   string // 编码
 	weight int    // 权重
+}
+
+// filterType:
+// 1.只匹配原本为全小写的
+// 2.仅首字母转为小写 如：Windows XP → windows xP
+// 3.全部转为小写
+// cutOffType: 1 去除空格 2 去除连字符"-" 3 去除空格及连字符
+type rule4EngEntry struct {
+	filterType int // 汉字
+	cutOffType int // 权重
 }
 
 var (
@@ -31,11 +42,18 @@ var (
 	BasePath    = filepath.Join(RimeDir, "cn_dicts/base.dict.yaml")
 	ExtPath     = filepath.Join(RimeDir, "cn_dicts/ext.dict.yaml")
 	TencentPath = filepath.Join(RimeDir, "cn_dicts/tencent.dict.yaml")
+	EnPath      = filepath.Join(RimeDir, "en_dicts/en.dict.yaml")
+	EnExtPath   = filepath.Join(RimeDir, "en_dicts/en_ext.dict.yaml")
+
+	rule4En    = rule4EngEntry{1, 3}
+	rule4EnExt = rule4EngEntry{2, 3}
 
 	HanziSet   = readToSet(HanziPath)
 	BaseSet    = readToSet(BasePath)
 	ExtSet     = readToSet(ExtPath)
 	TencentSet = readToSet(TencentPath)
+	EnSet      = readToSet4Eng(EnPath, rule4En)
+	EnExtSet   = readToSet4Eng(EnExtPath, rule4EnExt)
 
 	需要注音TXT   = filepath.Join(RimeDir, "others/script/rime/需要注音.txt")
 	错别字TXT    = filepath.Join(RimeDir, "others/script/rime/错别字.txt")
@@ -67,6 +85,96 @@ func readToSet(dictPath string) mapset.Set[string] {
 	}
 
 	return set
+}
+
+// 将所有词库读入 set，供检查或排序使用
+func readToSet4Eng(dictPath string, rule rule4EngEntry) mapset.Set[string] {
+	set := mapset.NewSet[string]()
+
+	file, err := os.Open(dictPath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer file.Close()
+
+	sc := bufio.NewScanner(file)
+	isMark := false
+	for sc.Scan() {
+		line := sc.Text()
+		if !isMark {
+			if strings.HasPrefix(line, mark) {
+				isMark = true
+			}
+			continue
+		}
+		if rule.filterType == 1 && !isLowercase(line) {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+
+		text, code := parts[0], strings.ToLower(parts[1])
+
+		set.Add(getKey4EngSet(text, code, rule))
+	}
+
+	return set
+}
+
+func getKey4EngSet(text string, code string, rule rule4EngEntry) string {
+	if rule.filterType == 2 {
+		text = convertFirstLetterToLower(text)
+	} else if rule.filterType == 3 {
+		text = strings.ToLower(text)
+	}
+
+	if rule.cutOffType == 2 || rule.cutOffType == 3 {
+		code = modifyText(text, 2)
+	}
+
+	return modifyText(text, rule.cutOffType) + code
+}
+
+func modifyText(text string, cutOffType int) string {
+	switch cutOffType {
+	case 1:
+		return strings.ReplaceAll(text, " ", "")
+	case 2:
+		return strings.ReplaceAll(text, "-", "")
+	case 3:
+		text = strings.ReplaceAll(text, " ", "")
+		return strings.ReplaceAll(text, "-", "")
+	default:
+		return text
+	}
+}
+
+// 首字母大写的单词，仅将首字母转为小写
+func convertFirstLetterToLower(s string) string {
+	var builder strings.Builder
+	words := strings.Fields(s)
+	for _, word := range words {
+		if len(word) > 0 && unicode.IsUpper(rune(word[0])) {
+			builder.WriteRune(unicode.ToLower(rune(word[0])))
+			if len(word) > 1 {
+				builder.WriteString(word[1:])
+			}
+		} else {
+			builder.WriteString(word)
+		}
+		builder.WriteRune(' ')
+	}
+	result := builder.String()
+	return strings.TrimSpace(result)
+}
+
+// 检查是否全为小写
+func isLowercase(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) && !unicode.IsLower(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // 打印耗时时间


### PR DESCRIPTION
对en_ext去重，包括自身重复的词条，以及在en中已有的词条

目前有几点问题：
1.en.dict中词条未做大小写区分：
应首字母大写的常规词：
```
british -> British
darwin -> Darwin
disney -> Disney
...
```
以及主流词典未收录但较常见的词条，也应当大写首字母：
```
chrome -> Chrome
nokia -> Nokia
...
```
这些词条会影响对ex_ext的去重判断

2.单词中的空格和连字符
例如：
`white space`  《美国传统词典》收录
`whitespace`  VSCode settings 使用单词形式

这种是否要分别收录？还是只保留其中一种形式？只留一种应以哪个为准？