### PR TITLE
feat: C键计算器

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -243,6 +243,11 @@ key_binder:
     - {accept: KP_8, send: 8, when: composing}
     - {accept: KP_9, send: 9, when: composing}
     - {accept: KP_Decimal, send: period, when: composing}
+    # 将小键盘 + - * / 映射到主键盘，使计算器 如 1+2-3*4 可使用小键盘输入
+    - {accept: KP_Multiply, send: asterisk, when: composing}
+    - {accept: KP_Add,      send: plus,     when: composing}
+    - {accept: KP_Subtract, send: minus,    when: composing}
+    - {accept: KP_Divide,   send: slash,    when: composing}
 
 
 # 按键速查

--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -79,6 +79,7 @@ engine:
     - table_translator@radical_lookup   # 部件拆字反查
     - lua_translator@unicode            # Unicode
     - lua_translator@number_translator  # 数字、金额大写
+    - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
     - lua_filter@corrector                          # 错音错字提示
@@ -290,6 +291,7 @@ recognizer:
     radical_lookup: "^uU[a-z]+$"        # 响应部件拆字的反查，与 radical_lookup/prefix 匹配
     unicode: "^U[a-f0-9]+"              # 脚本将自动获取第 2 个字符 U 作为触发前缀，响应 lua_translator@unicode，输出 Unicode 字符
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@number_translator，数字金额大写
+    calculator: "^C.+"                  # 脚本将自动获取第 2 个字符 C 作为触发前缀，响应 lua_translator@calc_translator，计算器
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
 
 

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -79,6 +79,7 @@ engine:
     - table_translator@radical_lookup   # 部件拆字反查
     - lua_translator@unicode            # Unicode
     - lua_translator@number_translator  # 数字、金额大写
+    - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
     - lua_filter@corrector                          # 错音错字提示
@@ -293,6 +294,7 @@ recognizer:
     radical_lookup: "^uU[a-z]+$"        # 响应部件拆字的反查，与 radical_lookup/prefix 匹配
     unicode: "^U[a-f0-9]+"              # 脚本将自动获取第 2 个字符 U 作为触发前缀，响应 lua_translator@unicode，输出 Unicode 字符
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@number_translator，数字金额大写
+    calculator: "^C.+"                  # 脚本将自动获取第 2 个字符 C 作为触发前缀，响应 lua_translator@calc_translator，计算器
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
 
 

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -79,6 +79,7 @@ engine:
     - table_translator@radical_lookup   # 部件拆字反查
     - lua_translator@unicode            # Unicode
     - lua_translator@number_translator  # 数字、金额大写
+    - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
     - lua_filter@corrector                          # 错音错字提示
@@ -290,6 +291,7 @@ recognizer:
     radical_lookup: "^uU[a-z]+$"        # 响应部件拆字的反查，与 radical_lookup/prefix 匹配
     unicode: "^U[a-f0-9]+"              # 脚本将自动获取第 2 个字符 U 作为触发前缀，响应 lua_translator@unicode，输出 Unicode 字符
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@number_translator，数字金额大写
+    calculator: "^C.+"                  # 脚本将自动获取第 2 个字符 C 作为触发前缀，响应 lua_translator@calc_translator，计算器
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
 
 

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -79,6 +79,7 @@ engine:
     - table_translator@radical_lookup   # 部件拆字反查
     - lua_translator@unicode            # Unicode
     - lua_translator@number_translator  # 数字、金额大写
+    - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
     - lua_filter@corrector                          # 错音错字提示
@@ -294,6 +295,7 @@ recognizer:
     radical_lookup: "^uU[a-z;]+$"       # 响应部件拆字的反查，与 radical_lookup/prefix 匹配
     unicode: "^U[a-f0-9]+"              # 脚本将自动获取第 2 个字符 U 作为触发前缀，响应 lua_translator@unicode，输出 Unicode 字符
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@number_translator，数字金额大写
+    calculator: "^C.+"                  # 脚本将自动获取第 2 个字符 C 作为触发前缀，响应 lua_translator@calc_translator，计算器
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
 
 

--- a/double_pinyin_sogou.schema.yaml
+++ b/double_pinyin_sogou.schema.yaml
@@ -79,6 +79,7 @@ engine:
     - table_translator@radical_lookup   # 部件拆字反查
     - lua_translator@unicode            # Unicode
     - lua_translator@number_translator  # 数字、金额大写
+    - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
     - lua_filter@corrector                          # 错音错字提示
@@ -294,6 +295,7 @@ recognizer:
     radical_lookup: "^uU[a-z;]+$"       # 响应部件拆字的反查，与 radical_lookup/prefix 匹配
     unicode: "^U[a-f0-9]+"              # 脚本将自动获取第 2 个字符 U 作为触发前缀，响应 lua_translator@unicode，输出 Unicode 字符
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@number_translator，数字金额大写
+    calculator: "^C.+"                  # 脚本将自动获取第 2 个字符 C 作为触发前缀，响应 lua_translator@calc_translator，计算器
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
 
 

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -79,6 +79,7 @@ engine:
     - table_translator@radical_lookup   # 部件拆字反查
     - lua_translator@unicode            # Unicode
     - lua_translator@number_translator  # 数字、金额大写
+    - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
     - lua_filter@corrector                          # 错音错字提示
@@ -292,6 +293,7 @@ recognizer:
     radical_lookup: "^uU[a-z;]+$"       # 响应部件拆字的反查，与 radical_lookup/prefix 匹配
     unicode: "^U[a-f0-9]+"              # 脚本将自动获取第 2 个字符 U 作为触发前缀，响应 lua_translator@unicode，输出 Unicode 字符
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@number_translator，数字金额大写
+    calculator: "^C.+"                  # 脚本将自动获取第 2 个字符 C 作为触发前缀，响应 lua_translator@calc_translator，计算器
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
 
 

--- a/lua/calculator.lua
+++ b/lua/calculator.lua
@@ -1,0 +1,244 @@
+-- author: https://github.com/ChaosAlphard
+
+local M = {}
+
+function M.init(env)
+    local config = env.engine.schema.config
+    M.prefix = config:get_string('recognizer/patterns/calculator'):sub(2, 2) or 'C'
+end
+
+local function startsWith(str, start)
+    return string.sub(str, 1, string.len(start)) == start
+end
+
+local function truncateFromStart(str, truncateStr)
+    return string.sub(str, string.len(truncateStr) + 1)
+end
+
+-- 函数表
+local calcPlugin = {
+    -- e, exp(1) = e^1 = e
+    e = math.exp(1),
+    -- π
+    pi = math.pi
+}
+
+-- random([m [,n ]]) 返回m-n之间的随机数, n为空则返回1-m之间, 都为空则返回0-1之间的小数
+local function random(...)
+    return math.random(...)
+end
+-- 注册到函数表中
+calcPlugin["rdm"] = random
+
+-- 正弦
+local function sin(x)
+    return math.sin(x)
+end
+calcPlugin["sin"] = sin
+
+-- 双曲正弦
+local function sinh(x)
+    return math.sinh(x)
+end
+calcPlugin["sinh"] = sinh
+
+-- 反正弦
+local function asin(x)
+    return math.asin(x)
+end
+calcPlugin["asin"] = asin
+
+-- 余弦
+local function cos(x)
+    return math.cos(x)
+end
+calcPlugin["cos"] = cos
+
+-- 双曲余弦
+local function cosh(x)
+    return math.cosh(x)
+end
+calcPlugin["cosh"] = cosh
+
+-- 反余弦
+local function acos(x)
+    return math.acos(x)
+end
+calcPlugin["acos"] = acos
+
+-- 正切
+local function tan(x)
+    return math.tan(x)
+end
+calcPlugin["tan"] = tan
+
+-- 双曲正切
+local function tanh(x)
+    return math.tanh(x)
+end
+calcPlugin["tanh"] = tanh
+
+-- 反正切
+-- 返回以弧度为单位的点相对于x轴的逆时针角度。x是点的横纵坐标比值
+-- 返回范围从−π到π （以弧度为单位），其中负角度表示向下旋转，正角度表示向上旋转
+local function atan(x)
+    return math.atan(x)
+end
+calcPlugin["atan"] = atan
+
+-- 反正切
+-- atan( y/x ) = atan2(y, x)
+-- 返回以弧度为单位的点相对于x轴的逆时针角度。y是点的纵坐标，x是点的横坐标
+-- 返回范围从−π到π （以弧度为单位），其中负角度表示向下旋转，正角度表示向上旋转
+-- 与 math.atan(y/x) 函数相比，具有更好的数学定义，因为它能够正确处理边界情况（例如x=0）
+local function atan2(y, x)
+    return math.atan2(y, x)
+end
+calcPlugin["atan2"] = atan2
+
+-- 将角度从弧度转换为度 e.g. deg(π) = 180
+local function deg(x)
+    return math.deg(x)
+end
+calcPlugin["deg"] = deg
+
+-- 将角度从度转换为弧度 e.g. rad(180) = π
+local function rad(x)
+    return math.rad(x)
+end
+calcPlugin["rad"] = rad
+
+-- 返回两个值, 无法参与运算后续, 只能单独使用
+-- 返回m,e 使得x = m * 2^e
+local function frexp(x)
+    local m, e = math.frexp(x)
+    return m .. " * 2^" .. e
+end
+calcPlugin["frexp"] = frexp
+
+-- 返回 x * 2^y
+local function ldexp(x, y)
+    return math.ldexp(x, y)
+end
+calcPlugin["ldexp"] = ldexp
+
+-- 返回 e^x
+local function exp(x)
+    return math.exp(x)
+end
+calcPlugin["exp"] = exp
+
+-- 返回x的平方根 e.g. sqrt(x) = x^0.5
+local function sqrt(x)
+    return math.sqrt(x)
+end
+calcPlugin["sqrt"] = sqrt
+
+-- y为底x的对数, 使用换底公式实现
+local function log(y, x)
+    -- 不能为负数或0
+    if x <= 0 or y <= 0 then return nil end
+
+    return math.log(x) / math.log(y)
+end
+calcPlugin["log"] = log
+
+-- e为底x的对数
+local function loge(x)
+    -- 不能为负数或0
+    if x <= 0 then return nil end
+
+    return math.log(x)
+end
+calcPlugin["loge"] = loge
+
+-- 10为底x的对数
+local function log10(x)
+    -- 不能为负数或0
+    if x <= 0 then return nil end
+
+    return math.log10(x)
+end
+calcPlugin["log10"] = log10
+
+-- 平均值
+local function avg(...)
+    local data = {...}
+    local n = select("#", ...)
+    -- 样本数量不能为0
+    if n == 0 then return nil end
+
+    -- 计算总和
+    local sum = 0
+    for _, value in ipairs(data) do
+        sum = sum + value
+    end
+
+    return sum / n
+end
+calcPlugin["avg"] = avg
+
+-- 方差
+local function variance(...)
+    local data = {...}
+    local n = select("#", ...)
+    -- 样本数量不能为0
+    if n == 0 then return nil end
+
+    -- 计算均值
+    local sum = 0
+    for _, value in ipairs(data) do
+        sum = sum + value
+    end
+    local mean = sum / n
+
+    -- 计算方差
+    local sum_squared_diff = 0
+    for _, value in ipairs(data) do
+        sum_squared_diff = sum_squared_diff + (value - mean)^2
+    end
+
+    return sum_squared_diff / n
+end
+calcPlugin["var"] = variance
+
+-- 阶乘
+local function factorial(x)
+    -- 不能为负数
+    if x < 0 then return nil end
+    if x == 0 or x == 1 then return 1 end
+
+    local result = 1
+    for i = 1, x do
+        result = result * i
+    end
+
+    return result
+end
+calcPlugin["fact"] = factorial
+
+-- 实现阶乘计算(!)
+local function replaceToFactorial(str)
+    -- 替换[0-9]!字符为fact([0-9])以实现阶乘
+    return str:gsub("([0-9]+)!", "fact(%1)")
+end
+
+-- 简单计算器
+function M.func(input, seg, env)
+    if not startsWith(input, M.prefix) then return end
+    -- 提取算式
+    local express = truncateFromStart(input, M.prefix)
+
+    local code = replaceToFactorial(express)
+
+    local success, result = pcall(load("return " .. code, "calculate", "t", calcPlugin))
+    if success then
+        yield(Candidate(input, seg.start, seg._end, result, ""))
+        yield(Candidate(input, seg.start, seg._end, express .. "=" .. result, ""))
+    else
+        yield(Candidate(input, seg.start, seg._end, express, "解析失败"))
+        yield(Candidate(input, seg.start, seg._end, code, "入参"))
+    end
+end
+
+return M

--- a/rime.lua
+++ b/rime.lua
@@ -20,6 +20,9 @@ unicode = require("unicode")
 -- 数字、人民币大写，R 开头
 number_translator = require("number_translator")
 
+-- 计算器
+calc_translator = require("calculator")
+
 -- filters:
 
 -- 错音错字提示

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -68,6 +68,7 @@ engine:
     - table_translator@radical_lookup   # 部件拆字反查
     - lua_translator@unicode            # Unicode
     - lua_translator@number_translator  # 数字、金额大写
+    - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
     - lua_filter@corrector                          # 错音错字提示
@@ -393,6 +394,7 @@ recognizer:
     radical_lookup: "^uU[a-z]+$"        # 响应部件拆字的反查，与 radical_lookup/prefix 匹配
     unicode: "^U[a-f0-9]+"              # 脚本将自动获取第 2 个字符 U 作为触发前缀，响应 lua_translator@unicode，输出 Unicode 字符
     number: "^R[0-9]+[.]?[0-9]*"        # 脚本将自动获取第 2 个字符 R 作为触发前缀，响应 lua_translator@number_translator，数字金额大写
+    calculator: "^C.+"                  # 脚本将自动获取第 2 个字符 C 作为触发前缀，响应 lua_translator@calc_translator，计算器
     gregorian_to_lunar: "^N[0-9]{1,8}"  # 脚本将自动获取第 2 个字符 N 作为触发前缀，响应 lua_translator@lunar，公历转农历，输入 N20240115 得到「二〇二三年腊月初五」
 
 


### PR DESCRIPTION
类似搜狗输入法的V模式，这里用的C键触发

支持 `+ - * / % ^` 运算符

![图片](https://github.com/iDvel/rime-ice/assets/26186575/d3fc8714-a292-482a-a7a3-f9fbb420442a)

![图片](https://github.com/iDvel/rime-ice/assets/26186575/b85b6b93-0f7e-47ac-9eb0-e07d969a45d2)


支持正弦、反正弦、余弦、反余弦、正切、反正切、平方根、弧度转度、度转弧度、对数、平均值、方差等函数

![图片](https://github.com/iDvel/rime-ice/assets/26186575/6cb10800-5fce-4013-a486-964d2b943a68)

![图片](https://github.com/iDvel/rime-ice/assets/26186575/d2e100cf-8b1e-4938-ad3b-0fd08e9f7319)

![图片](https://github.com/iDvel/rime-ice/assets/26186575/6fd7df47-7c3f-4f5f-8675-84fcd41ce7ae)

log(y, x) = $\log_{y}(x)$

![图片](https://github.com/iDvel/rime-ice/assets/26186575/243db4b5-dae3-48a7-a335-39784b3fc39c)

额外支持生成随机数

![gif](https://github.com/iDvel/rime-ice/assets/26186575/01c44b76-2f47-46a4-948b-ab7e2f6a4023)


