### PR TITLE
feat: 限定多音节补全候选个数为 1 【看到的用户可以用表情说明需不需要这个功能】

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -82,6 +82,7 @@ engine:
     - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
+    - lua_filter@completion_filter                  # 限制多音节补全的候选词个数
     - lua_filter@corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@autocap_filter                     # 英文自动大写
@@ -158,7 +159,8 @@ pin_cand_filter:
 # 主翻译器，拼音
 translator:
   dictionary: rime_ice          # 挂载词库 rime_ice.dict.yaml
-  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime > 1.11.2
+  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime ≥ 1.12
+  word_completion_count: 1      # 大于 4 音节的词条补全候选个数，via completion_filter.lua librime ≥ 1.11
   prism: double_pinyin          # 多方案共用一个词库时，为避免冲突，需要用 prism 指定一个名字。
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -82,6 +82,7 @@ engine:
     - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
+    - lua_filter@completion_filter                  # 限制多音节补全的候选词个数
     - lua_filter@corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@autocap_filter                     # 英文自动大写
@@ -158,7 +159,8 @@ pin_cand_filter:
 # 主翻译器，拼音
 translator:
   dictionary: rime_ice          # 挂载词库 rime_ice.dict.yaml
-  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime > 1.11.2
+  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime ≥ 1.12
+  word_completion_count: 1      # 大于 4 音节的词条补全候选个数，via completion_filter.lua librime ≥ 1.11
   prism: double_pinyin_abc      # 多方案共用一个词库时，为避免冲突，需要用 prism 指定一个名字。
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -82,6 +82,7 @@ engine:
     - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
+    - lua_filter@completion_filter                  # 限制多音节补全的候选词个数
     - lua_filter@corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@autocap_filter                     # 英文自动大写
@@ -158,7 +159,8 @@ pin_cand_filter:
 # 主翻译器，拼音
 translator:
   dictionary: rime_ice          # 挂载词库 rime_ice.dict.yaml
-  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime > 1.11.2
+  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime ≥ 1.12
+  word_completion_count: 1      # 大于 4 音节的词条补全候选个数，via completion_filter.lua librime ≥ 1.11
   prism: double_pinyin_flypy    # 多方案共用一个词库时，为避免冲突，需要用 prism 指定一个名字。
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -82,6 +82,7 @@ engine:
     - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
+    - lua_filter@completion_filter                  # 限制多音节补全的候选词个数
     - lua_filter@corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@autocap_filter                     # 英文自动大写
@@ -158,7 +159,8 @@ pin_cand_filter:
 # 主翻译器，拼音
 translator:
   dictionary: rime_ice          # 挂载词库 rime_ice.dict.yaml
-  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime > 1.11.2
+  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime ≥ 1.12
+  word_completion_count: 1      # 大于 4 音节的词条补全候选个数，via completion_filter.lua librime ≥ 1.11
   prism: double_pinyin_mspy     # 多方案共用一个词库时，为避免冲突，需要用 prism 指定一个名字。
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。

--- a/double_pinyin_sogou.schema.yaml
+++ b/double_pinyin_sogou.schema.yaml
@@ -82,6 +82,7 @@ engine:
     - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
+    - lua_filter@completion_filter                  # 限制多音节补全的候选词个数
     - lua_filter@corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@autocap_filter                     # 英文自动大写
@@ -158,7 +159,8 @@ pin_cand_filter:
 # 主翻译器，拼音
 translator:
   dictionary: rime_ice          # 挂载词库 rime_ice.dict.yaml
-  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime > 1.11.2
+  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime ≥ 1.12
+  word_completion_count: 1      # 大于 4 音节的词条补全候选个数，via completion_filter.lua librime ≥ 1.11
   prism: double_pinyin_sogou    # 多方案共用一个词库时，为避免冲突，需要用 prism 指定一个名字。
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -82,6 +82,7 @@ engine:
     - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
+    - lua_filter@completion_filter                  # 限制多音节补全的候选词个数
     - lua_filter@corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@autocap_filter                     # 英文自动大写
@@ -158,7 +159,8 @@ pin_cand_filter:
 # 主翻译器，拼音
 translator:
   dictionary: rime_ice          # 挂载词库 rime_ice.dict.yaml
-  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime > 1.11.2
+  enable_word_completion: true  # 大于 4 音节的词条自动补全，librime ≥ 1.12
+  word_completion_count: 1      # 大于 4 音节的词条补全候选个数，via completion_filter.lua librime ≥ 1.11
   prism: double_pinyin_ziguang  # 多方案共用一个词库时，为避免冲突，需要用 prism 指定一个名字。
   spelling_hints: 8             # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true    # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。

--- a/lua/completion_filter.lua
+++ b/lua/completion_filter.lua
@@ -1,0 +1,23 @@
+local completion_filter = {}
+
+function completion_filter.init( env )
+    env.completion_cand_count = env.engine.schema.config:get_int( 'translator/word_completion_count' ) or 1 -- set to 0 to disable
+end
+
+function completion_filter.func( input, env )
+    local completion_cand_count = 0
+    for cand in input:iter() do
+        -- 对于 rime-ice 而言，实际上可以判断 cand.comment 是否含有标记
+        -- 但是这里为了通用，所以只判断文本是否含有英文字符
+        if env.completion_cand_count > 0 and cand.type == 'completion' and not cand.text:find( '%a' ) then
+            completion_cand_count = completion_cand_count + 1
+            if completion_cand_count > env.completion_cand_count then goto skip end
+        end
+        yield( cand )
+        ::skip::
+    end
+end
+
+function completion_filter.tags_match( seg, env ) if seg.tags['abc'] then return true end end
+
+return completion_filter

--- a/rime.lua
+++ b/rime.lua
@@ -25,6 +25,9 @@ calc_translator = require("calc_translator")
 
 -- filters:
 
+-- 限定补全词的个数，配置项 translator/word_completion_count，默认 1，librime ≥ 1.11
+completion_filter = require("completion_filter")
+
 -- 错音错字提示
 -- 关闭此 Lua 时，同时需要关闭 translator/spelling_hints，否则 comment 里都是拼音
 corrector = require("corrector")

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -71,6 +71,7 @@ engine:
     - lua_translator@calc_translator    # 计算器
     - lua_translator@force_gc           # 暴力 GC
   filters:
+    - lua_filter@completion_filter                  # 限制多音节补全的候选词个数
     - lua_filter@corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@autocap_filter                     # 英文自动大写
@@ -292,7 +293,8 @@ pin_cand_filter:
 # 主翻译器，拼音
 translator:
   dictionary: rime_ice         # 挂载词库 rime_ice.dict.yaml
-  enable_word_completion: true # 大于 4 音节的词条自动补全，librime > 1.11.2
+  enable_word_completion: true # 大于 4 音节的词条自动补全，librime ≥ 1.12
+  word_completion_count: 1     # 大于 4 音节的词条补全候选个数，via completion_filter.lua librime ≥ 1.12
   spelling_hints: 8            # corrector.lua ：为了让错音错字提示的 Lua 同时适配全拼双拼，将拼音显示在 comment 中
   always_show_comments: true   # corrector.lua ：Rime 默认在 preedit 等于 comment 时取消显示 comment，这里强制一直显示，供 corrector.lua 做判断用。
   initial_quality: 1.2         # 拼音的权重应该比英文大


### PR DESCRIPTION
功能：限定 script_translator 的多音节补全候选个数。类似 macOS 预装输入法那样

未添加本功能：输入`中华人民`，`广东东莞`，大量补全词填满候选：

![image](https://github.com/user-attachments/assets/6d03160d-ae09-423a-a7d8-c9b66450a1ea)

![image](https://github.com/user-attachments/assets/e731151e-71f8-43a7-8a68-8e351ad6c34d)

添加本功能：只显示一个权重最高的补全词

![image](https://github.com/user-attachments/assets/6dc15c7d-25b9-4ed5-a162-18d32f437944)

![image](https://github.com/user-attachments/assets/46c65088-8ff2-4661-9a3a-2edc9be4d3ef)
