### PR TITLE
修正reduce_english_filter.lua会吞掉英文候选词的问题

### DIFF
--- a/lua/reduce_english_filter.lua
+++ b/lua/reduce_english_filter.lua
@@ -97,11 +97,12 @@ function M.func(input, env)
                 table.insert(pending_cands, cand)
             end
             if index >= M.idx + #pending_cands - 1 then
-                for _, cand in ipairs(pending_cands) do
-                    yield(cand)
-                end
                 break
             end
+        end
+        -- 将pending_cands按顺序输出
+        for _, cand in ipairs(pending_cands) do
+            yield(cand)
         end
     end
 


### PR DESCRIPTION
修正reduce_english_filter.lua在遍历完全部候选词后, 如果未到达设定的idx, 会吞掉pending_cands中未输出的英文候选词的问题

fix #1273 